### PR TITLE
Update dependencies

### DIFF
--- a/Backbone.API/Program.cs
+++ b/Backbone.API/Program.cs
@@ -7,8 +7,15 @@ using Backbone.API.Configuration;
 using Backbone.API.Extensions;
 using Backbone.API.Mvc.Middleware;
 using Backbone.Infrastructure.EventBus;
+using Backbone.Modules.Challenges.Infrastructure.Persistence.Database;
 using Backbone.Modules.Devices.Application.Extensions;
+using Backbone.Modules.Devices.Infrastructure.Persistence.Database;
+using Backbone.Modules.Files.Infrastructure.Persistence.Database;
+using Backbone.Modules.Messages.Infrastructure.Persistence.Database;
+using Backbone.Modules.Relationships.Infrastructure.Persistence.Database;
 using Backbone.Modules.Synchronization.Application.Extensions;
+using Backbone.Modules.Synchronization.Infrastructure.Persistence.Database;
+using Backbone.Modules.Tokens.Infrastructure.Persistence.Database;
 using Enmeshed.BuildingBlocks.Application.Abstractions.Infrastructure.EventBus;
 using Enmeshed.Tooling.Extensions;
 using Microsoft.ApplicationInsights.Extensibility;
@@ -43,13 +50,13 @@ var app = builder.Build();
 Configure(app);
 
 app
-    .MigrateDbContext<Backbone.Modules.Challenges.Infrastructure.Persistence.Database.ChallengesDbContext>()
-    .MigrateDbContext<Backbone.Modules.Devices.Infrastructure.Persistence.Database.DevicesDbContext>((context, _) => { new DevicesDbContextSeed().SeedAsync(context).Wait(); })
-    .MigrateDbContext<Backbone.Modules.Files.Infrastructure.Persistence.Database.FilesDbContext>()
-    .MigrateDbContext<Backbone.Modules.Relationships.Infrastructure.Persistence.Database.RelationshipsDbContext>()
-    .MigrateDbContext<Backbone.Modules.Messages.Infrastructure.Persistence.Database.MessagesDbContext>()
-    .MigrateDbContext<Backbone.Modules.Synchronization.Infrastructure.Persistence.Database.SynchronizationDbContext>()
-    .MigrateDbContext<Backbone.Modules.Tokens.Infrastructure.Persistence.Database.TokensDbContext>();
+    .MigrateDbContext<ChallengesDbContext>()
+    .MigrateDbContext<DevicesDbContext>((context, _) => { new DevicesDbContextSeed().SeedAsync(context).Wait(); })
+    .MigrateDbContext<FilesDbContext>()
+    .MigrateDbContext<RelationshipsDbContext>()
+    .MigrateDbContext<MessagesDbContext>()
+    .MigrateDbContext<SynchronizationDbContext>()
+    .MigrateDbContext<TokensDbContext>();
 
 app.Run();
 

--- a/BuildingBlocks/src/BuildingBlocks.Infrastructure/BuildingBlocks.Infrastructure.csproj
+++ b/BuildingBlocks/src/BuildingBlocks.Infrastructure/BuildingBlocks.Infrastructure.csproj
@@ -20,7 +20,7 @@
 		<PackageReference Include="Microsoft.Extensions.Identity.Core" Version="7.0.5" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
-		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.3" />
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.4" />
 		<PackageReference Include="Polly" Version="7.2.3" />
 		<PackageReference Include="RabbitMQ.Client" Version="6.5.0" />
 		<PackageReference Include="System.Interactive.Async" Version="6.0.1" />

--- a/Modules/Challenges/src/Challenges.Infrastructure/Challenges.Infrastructure.csproj
+++ b/Modules/Challenges/src/Challenges.Infrastructure/Challenges.Infrastructure.csproj
@@ -10,7 +10,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.5" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.5" />
-		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.3" />
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.4" />
 		<PackageReference Include="System.Interactive.Async" Version="6.0.1" />
 	</ItemGroup>
 

--- a/Modules/Devices/src/Devices.Application/Devices.Application.csproj
+++ b/Modules/Devices/src/Devices.Application/Devices.Application.csproj
@@ -11,7 +11,7 @@
 		<PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
 		<PackageReference Include="FluentValidation" Version="11.5.2" />
 		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.5.2" />
-		<PackageReference Include="Microsoft.IdentityModel.Tokens" Version="[6.27.0]" />
+		<PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.30.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Modules/Devices/src/Devices.Infrastructure/Devices.Infrastructure.csproj
+++ b/Modules/Devices/src/Devices.Infrastructure/Devices.Infrastructure.csproj
@@ -21,7 +21,7 @@
 		<PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="7.0.5" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
-		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.3" />
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.4" />
 		<PackageReference Include="OpenIddict.AspNetCore" Version="4.2.0" />
 		<PackageReference Include="OpenIddict.EntityFrameworkCore" Version="4.2.0" />
 		<PackageReference Include="Polly" Version="7.2.3" />

--- a/Modules/Files/src/Files.Infrastructure/Files.Infrastructure.csproj
+++ b/Modules/Files/src/Files.Infrastructure/Files.Infrastructure.csproj
@@ -16,7 +16,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.5" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.5" />
-		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.3" />
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.4" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Modules/Messages/src/Messages.Infrastructure/Messages.Infrastructure.csproj
+++ b/Modules/Messages/src/Messages.Infrastructure/Messages.Infrastructure.csproj
@@ -10,7 +10,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.5" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.5" />
-		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.3" />
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.4" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Modules/Relationships/src/Relationships.Infrastructure/Relationships.Infrastructure.csproj
+++ b/Modules/Relationships/src/Relationships.Infrastructure/Relationships.Infrastructure.csproj
@@ -10,7 +10,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.5" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.5" />
-		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.3" />
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.4" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Modules/Synchronization/src/Synchronization.Infrastructure/Synchronization.Infrastructure.csproj
+++ b/Modules/Synchronization/src/Synchronization.Infrastructure/Synchronization.Infrastructure.csproj
@@ -18,7 +18,7 @@
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.5" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.5" />
 		<PackageReference Include="Azure.Messaging.ServiceBus" Version="7.13.1" />
-		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.3" />
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.4" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Modules/Tokens/src/Tokens.Infrastructure/Tokens.Infrastructure.csproj
+++ b/Modules/Tokens/src/Tokens.Infrastructure/Tokens.Infrastructure.csproj
@@ -10,7 +10,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.5" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.5" />
-		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.3" />
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.4" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
This includes an update of the `Microsoft.IdentityModel.Tokens` library. The previous two versions of this library caused an authentication error in our application, which resulted in an 401 on every route of the Consumer API, which is why I have pinned version 6.27.0 (see https://github.com/nmshd/backbone/commit/2ddea4d45331e5c146bfdb7b19a4032d6deb7876). The latest version fixes  the problem, so I made the update.

# Readiness checklist

- [ ] I added/updated unit tests.
- [ ] I added/updated integration tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.