### PR TITLE
Do not publish Consumer API as "backbone" anymore

### DIFF
--- a/.ci/capi/buildContainerImage.ts
+++ b/.ci/capi/buildContainerImage.ts
@@ -5,4 +5,4 @@ import { getRequiredEnvVar } from "../lib.js";
 
 const tag = getRequiredEnvVar("TAG");
 
-await $`docker build --file ./ConsumerApi/Dockerfile --tag ghcr.io/nmshd/backbone:${tag} --tag ghcr.io/nmshd/backbone-consumer-api:${tag} .`;
+await $`docker build --file ./ConsumerApi/Dockerfile --tag ghcr.io/nmshd/backbone-consumer-api:${tag} .`;

--- a/.ci/capi/pushContainerImage.ts
+++ b/.ci/capi/pushContainerImage.ts
@@ -5,5 +5,4 @@ import { getRequiredEnvVar } from "../lib.js";
 
 const tag = getRequiredEnvVar("TAG");
 
-await $`docker push ghcr.io/nmshd/backbone:${tag}`;
 await $`docker push ghcr.io/nmshd/backbone-consumer-api:${tag}`;


### PR DESCRIPTION
The `backbone` image is deprecated for quite some time now. With this PR, new versions will not be published with the `backbone` tag anymore.

# Readiness checklist

- [ ] I added/updated unit tests.
- [ ] I added/updated integration tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
