### PR TITLE
Exclude OpenIddict from Dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
       update-nuget-dependencies:
         patterns:
           - "*"
+        exclude-patterns:
+          - "OpenIddict.*"
     reviewers:
       - "tnotheis"
     labels:


### PR DESCRIPTION
We need to exclude OpenIddict for now, as JWTs will no longer be considered valid if we update to a version higher than 4.3.0.

# Readiness checklist

- [ ] I added/updated unit tests.
- [ ] I added/updated integration tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
