### PR TITLE
Error on consecutive calls to FirebaseMessagingFactory.CreateForAppId

### DIFF
--- a/Modules/Devices/src/Devices.Infrastructure/PushNotifications/DirectPush/FirebaseCloudMessaging/FirebaseMessagingFactory.cs
+++ b/Modules/Devices/src/Devices.Infrastructure/PushNotifications/DirectPush/FirebaseCloudMessaging/FirebaseMessagingFactory.cs
@@ -16,16 +16,17 @@ public class FirebaseMessagingFactory
 
     public FirebaseMessaging CreateForAppId(string appId)
     {
-        var firebaseApp = FirebaseApp.GetInstance(appId);
-        if (firebaseApp == null)
-        {
-            var serviceAccount = _options.GetServiceAccountForAppId(appId);
-            firebaseApp = FirebaseApp.Create(new AppOptions
-            {
-                Credential = GoogleCredential.FromJson(serviceAccount)
-            }, appId);
-        }
+        var firebaseApp = FirebaseApp.GetInstance(appId) ?? RegisterNewInstance(appId);
 
         return FirebaseMessaging.GetMessaging(firebaseApp);
+    }
+
+    private FirebaseApp RegisterNewInstance(string appId)
+    {
+        var serviceAccount = _options.GetServiceAccountForAppId(appId);
+        var credential = GoogleCredential.FromJson(serviceAccount);
+        var firebaseApp = FirebaseApp.Create(new AppOptions { Credential = credential }, appId);
+
+        return firebaseApp;
     }
 }

--- a/Modules/Devices/src/Devices.Infrastructure/PushNotifications/DirectPush/FirebaseCloudMessaging/FirebaseMessagingFactory.cs
+++ b/Modules/Devices/src/Devices.Infrastructure/PushNotifications/DirectPush/FirebaseCloudMessaging/FirebaseMessagingFactory.cs
@@ -23,7 +23,7 @@ public class FirebaseMessagingFactory
             firebaseApp = FirebaseApp.Create(new AppOptions
             {
                 Credential = GoogleCredential.FromJson(serviceAccount)
-            });
+            }, appId);
         }
 
         return FirebaseMessaging.GetMessaging(firebaseApp);


### PR DESCRIPTION
Before this fix, the second time `CreateForAppId` was called always resulted in an `ArgumentException` with the error message `The default FirebaseApp already exists.`.
To fix it, I had to add the `appId` as a parameter to the call to `FirebaseApp.Create` in line 28.

# Readiness checklist

-   [ ] I added/updated unit tests.
-   [ ] I added/updated integration tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.
