### PR TITLE
Enhance the log context with username

### DIFF
--- a/Backbone.Infrastructure/UserContext/AspNetCoreUserContext.cs
+++ b/Backbone.Infrastructure/UserContext/AspNetCoreUserContext.cs
@@ -12,6 +12,7 @@ public class AspNetCoreUserContext : IUserContext
     private const string ADDRESS_CLAIM = "address";
     private const string DEVICE_ID_CLAIM = "device_id";
     private const string USER_ID_CLAIM = "sub";
+    private const string USERNAME_CLAIM = "name";
     private const string SUBSCRIPTION_PLAN_CLAIM = "subscription_plan";
     private readonly IHttpContextAccessor _context;
 
@@ -66,7 +67,7 @@ public class AspNetCoreUserContext : IUserContext
 
     public string GetUsernameOrNull()
     {
-        var username = _context.HttpContext.User.Identities.First().Name;
+        var username = _context.HttpContext.User.FindFirstValue(USERNAME_CLAIM);
         return username;
     }
 

--- a/Backbone.Infrastructure/UserContext/AspNetCoreUserContext.cs
+++ b/Backbone.Infrastructure/UserContext/AspNetCoreUserContext.cs
@@ -59,6 +59,17 @@ public class AspNetCoreUserContext : IUserContext
         return userId;
     }
 
+    public string GetUsername()
+    {
+        return GetUsernameOrNull() ?? throw new NotFoundException();
+    }
+
+    public string GetUsernameOrNull()
+    {
+        var username = _context.HttpContext.User.Identities.First().Name;
+        return username;
+    }
+
     public IEnumerable<string> GetRoles()
     {
         var rolesClaim = _context.HttpContext.User.FindFirstValue(ClaimTypes.Role);

--- a/Backbone.Infrastructure/UserContext/AspNetCoreUserContext.cs
+++ b/Backbone.Infrastructure/UserContext/AspNetCoreUserContext.cs
@@ -12,7 +12,6 @@ public class AspNetCoreUserContext : IUserContext
     private const string ADDRESS_CLAIM = "address";
     private const string DEVICE_ID_CLAIM = "device_id";
     private const string USER_ID_CLAIM = "sub";
-    private const string USERNAME_CLAIM = "name";
     private const string SUBSCRIPTION_PLAN_CLAIM = "subscription_plan";
     private readonly IHttpContextAccessor _context;
 
@@ -67,7 +66,7 @@ public class AspNetCoreUserContext : IUserContext
 
     public string GetUsernameOrNull()
     {
-        var username = _context.HttpContext.User.FindFirstValue(USERNAME_CLAIM);
+        var username = _context.HttpContext.User.Identities.FirstOrDefault()?.Name;
         return username;
     }
 

--- a/BuildingBlocks/src/BuildingBlocks.Application.Abstractions/Infrastructure/UserContext/IUserContext.cs
+++ b/BuildingBlocks/src/BuildingBlocks.Application.Abstractions/Infrastructure/UserContext/IUserContext.cs
@@ -13,6 +13,9 @@ public interface IUserContext
     string GetUserId();
     string? GetUserIdOrNull();
 
+    string GetUsername();
+    string? GetUsernameOrNull();
+
     IEnumerable<string> GetRoles();
     SubscriptionPlan GetSubscriptionPlan();
 }

--- a/ConsumerApi/Mvc/Middleware/TraceIdMiddleware.cs
+++ b/ConsumerApi/Mvc/Middleware/TraceIdMiddleware.cs
@@ -1,6 +1,4 @@
-﻿using System.Diagnostics;
-
-namespace ConsumerApi.Mvc.Middleware;
+﻿namespace ConsumerApi.Mvc.Middleware;
 
 public class TraceIdMiddleware
 {

--- a/ConsumerApi/Mvc/Middleware/UserDataLoggingMiddleware.cs
+++ b/ConsumerApi/Mvc/Middleware/UserDataLoggingMiddleware.cs
@@ -1,7 +1,5 @@
 ﻿using Enmeshed.BuildingBlocks.Application.Abstractions.Infrastructure.UserContext;
-using Enmeshed.DevelopmentKit.Identity.ValueObjects;
 using Microsoft.AspNetCore;
-using Microsoft.Extensions.Azure;
 using Serilog.Context;
 using Serilog.Core;
 using Serilog.Core.Enrichers;

--- a/ConsumerApi/Mvc/Middleware/UserDataLoggingMiddleware.cs
+++ b/ConsumerApi/Mvc/Middleware/UserDataLoggingMiddleware.cs
@@ -22,18 +22,14 @@ public class UserDataLoggingMiddleware
         var deviceId = _userContext.GetDeviceIdOrNull();
         var identityAddress = _userContext.GetAddressOrNull();
 
-        List<ILogEventEnricher> enrichers = new()
+        ILogEventEnricher[] enrichers =
         {
             new PropertyEnricher("deviceId", deviceId ?? ""),
-            new PropertyEnricher("identityAddress", identityAddress ?? "")
+            new PropertyEnricher("identityAddress", identityAddress ?? ""),
+            new PropertyEnricher("username", _userContext.GetUsernameOrNull() ?? context.GetOpenIddictServerRequest()?.Username)
         };
 
-        if (deviceId is null || identityAddress is null)
-        {
-            enrichers.Add(new PropertyEnricher("username", context.GetOpenIddictServerRequest()?.Username));
-        }
-
-        using (LogContext.Push(enrichers.ToArray()))
+        using (LogContext.Push(enrichers))
         {
             await _next.Invoke(context);
         }

--- a/ConsumerApi/Mvc/Middleware/UserDataLoggingMiddleware.cs
+++ b/ConsumerApi/Mvc/Middleware/UserDataLoggingMiddleware.cs
@@ -24,13 +24,13 @@ public class UserDataLoggingMiddleware
         var deviceId = _userContext.GetDeviceIdOrNull();
         var identityAddress = _userContext.GetAddressOrNull();
 
-        List<ILogEventEnricher> enrichers = new ()
+        List<ILogEventEnricher> enrichers = new()
         {
             new PropertyEnricher("deviceId", deviceId ?? ""),
             new PropertyEnricher("identityAddress", identityAddress ?? "")
         };
 
-        if(deviceId is null || identityAddress is null)
+        if (deviceId is null || identityAddress is null)
         {
             enrichers.Add(new PropertyEnricher("username", context.GetOpenIddictServerRequest()?.Username));
         }

--- a/ConsumerApi/Mvc/Middleware/UserDataLoggingMiddleware.cs
+++ b/ConsumerApi/Mvc/Middleware/UserDataLoggingMiddleware.cs
@@ -21,12 +21,13 @@ public class UserDataLoggingMiddleware
     {
         var deviceId = _userContext.GetDeviceIdOrNull();
         var identityAddress = _userContext.GetAddressOrNull();
+        var username = _userContext.GetUsernameOrNull() ?? context.GetOpenIddictServerRequest()?.Username;
 
         ILogEventEnricher[] enrichers =
         {
             new PropertyEnricher("deviceId", deviceId ?? ""),
             new PropertyEnricher("identityAddress", identityAddress ?? ""),
-            new PropertyEnricher("username", _userContext.GetUsernameOrNull() ?? context.GetOpenIddictServerRequest()?.Username)
+            new PropertyEnricher("username", username ?? "")
         };
 
         using (LogContext.Push(enrichers))

--- a/Modules/Challenges/src/Challenges.Jobs.Cleanup/Program.cs
+++ b/Modules/Challenges/src/Challenges.Jobs.Cleanup/Program.cs
@@ -82,4 +82,14 @@ public class FakeUserContext : IUserContext
     {
         throw new NotImplementedException();
     }
+
+    public string GetUsername()
+    {
+        throw new NotImplementedException();
+    }
+
+    public string GetUsernameOrNull()
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/Modules/Quotas/test/Quotas.Application.Tests/TestDoubles/UserContextStub.cs
+++ b/Modules/Quotas/test/Quotas.Application.Tests/TestDoubles/UserContextStub.cs
@@ -44,4 +44,14 @@ internal class UserContextStub : IUserContext
     {
         throw new NotImplementedException();
     }
+
+    public string GetUsername()
+    {
+        throw new NotImplementedException();
+    }
+
+    public string GetUsernameOrNull()
+    {
+        throw new NotImplementedException();
+    }
 }


### PR DESCRIPTION
# Readiness checklist

-   [ ] I added/updated unit tests.
-   [ ] I added/updated integration tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.

# Description
Currently we log the identityAddress and the deviceId associated with a certain request for all log calls associated with that request. There is a special kind of requests, however. Requests to the `/connect/token` endpoint should somehow log what user did them, but the properties above are not set because there isn't a JWT yet. Thus, we open an exception for this scenario, logging the username directly from the request payload.

# Example
### Output:

```json
{
   "@t":"2023-09-27T08:35:07.6889720Z",
   "@mt":"The event {EventName} was marked as handled by {HandlerName}.",
   "@l":"Debug",
   "EventName":"OpenIddict.Server.OpenIddictServerEvents+ProcessSignInContext",
   "HandlerName":"OpenIddict.Server.OpenIddictServerHandlers+Exchange+ApplyTokenResponse`1[[OpenIddict.Server.OpenIddictServerEvents+ProcessSignInContext, OpenIddict.Server, Version=4.3.0.0, Culture=neutral, PublicKeyToken=****]]",
   "SourceContext":"OpenIddict.Server.OpenIddictServerDispatcher",
   "ActionId":"62feabce-cf4b-4eea-854d-e1106ff91ca1",
   "ActionName":"ConsumerApi.Controllers.AuthorizationController.Exchange (ConsumerApi)",
   "RequestId":"0HMTV6IFT6EFP:00000001",
   "RequestPath":"/connect/token",
   "ConnectionId":"0HMTV6IFT6EFP",
   "username":"USRa",
   "identityAddress":"",
   "deviceId":"",
   "CorrelationId":"f88153e7-2200-4d6f-9b5f-4eeb54aead13"
}
```