### PR TITLE
Rename logging configuration section and add configuration to default config

### DIFF
--- a/ConsumerApi/ConsumerApi.csproj
+++ b/ConsumerApi/ConsumerApi.csproj
@@ -25,6 +25,8 @@
 		<PackageReference Include="ReHackt.Extensions.Options.Validation" Version="7.0.1" />
 		<PackageReference Include="Serilog.Enrichers.ClientInfo" Version="2.0.1" />
 		<PackageReference Include="Serilog.Enrichers.Demystifier" Version="1.0.2" />
+		<PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
+		<PackageReference Include="Serilog.Exceptions.EntityFrameworkCore" Version="8.4.0" />
 		<PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="6.1.0" />

--- a/ConsumerApi/Program.cs
+++ b/ConsumerApi/Program.cs
@@ -47,7 +47,7 @@ LoadConfiguration(builder, args);
 
 builder.Host
     .UseSerilog((context, configuration) => configuration
-        .ReadFrom.Configuration(context.Configuration)
+        .ReadFrom.Configuration(context.Configuration, new ConfigurationReaderOptions { SectionName = "Logging" })
         .Enrich.WithCorrelationId("X-Correlation-Id", addValueIfHeaderAbsence: true)
         .Enrich.WithDemystifiedStackTraces()
         .Enrich.FromLogContext()

--- a/ConsumerApi/Program.cs
+++ b/ConsumerApi/Program.cs
@@ -34,6 +34,10 @@ using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Logging;
 using Serilog;
+using Serilog.Exceptions;
+using Serilog.Exceptions.Core;
+using Serilog.Exceptions.EntityFrameworkCore.Destructurers;
+using Serilog.Settings.Configuration;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.WebHost
@@ -51,6 +55,9 @@ builder.Host
         .Enrich.WithCorrelationId("X-Correlation-Id", addValueIfHeaderAbsence: true)
         .Enrich.WithDemystifiedStackTraces()
         .Enrich.FromLogContext()
+        .Enrich.WithExceptionDetails(new DestructuringOptionsBuilder()
+            .WithDefaultDestructurers()
+            .WithDestructurers(new[] { new DbUpdateExceptionDestructurer() }))
     )
     .UseServiceProviderFactory(new AutofacServiceProviderFactory());
 
@@ -194,4 +201,6 @@ static void LoadConfiguration(WebApplicationBuilder webApplicationBuilder, strin
     webApplicationBuilder.Configuration.AddAzureAppConfiguration();
 }
 
-public partial class Program { }
+public partial class Program
+{
+}

--- a/ConsumerApi/appsettings.json
+++ b/ConsumerApi/appsettings.json
@@ -71,5 +71,18 @@
                 }
             }
         }
+    },
+    "Logging": {
+        "MinimumLevel": {
+            "Default": "Error"
+        },
+        "WriteTo": {
+            "Console": {
+                "Name": "Console",
+                "Args": {
+                    "formatter": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact"
+                }
+            }
+        }
     }
 }

--- a/ConsumerApi/appsettings.override.json
+++ b/ConsumerApi/appsettings.override.json
@@ -126,7 +126,7 @@
             }
         }
     },
-    "Serilog": {
+    "Logging": {
         "Using": ["Serilog.Sinks.ApplicationInsights"],
         "MinimumLevel": {
             "Default": "Debug"

--- a/ConsumerApi/appsettings.override.json
+++ b/ConsumerApi/appsettings.override.json
@@ -127,18 +127,8 @@
         }
     },
     "Logging": {
-        "Using": ["Serilog.Sinks.ApplicationInsights"],
         "MinimumLevel": {
-            "Default": "Debug"
-        },
-        "Enrich": ["FromLogContext", "WithProcessId", "WithThreadId"],
-        "WriteTo": [
-            {
-                "Name": "Console",
-                "Args": {
-                  "formatter": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact"
-                }
-            }
-        ]
+            "Default": "Information"
+        }
     }
 }


### PR DESCRIPTION
# Readiness checklist

-   [ ] I added/updated unit tests.
-   [ ] I added/updated integration tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.

I thought about my answer I gave to @Dannyps during our last call. And I came to the conclusion that it might actually be a good idea to provide some default configuration for logging.

I also changed the configuration property from "Serilog" to "Logging", so that it is easier to understand by people that don't know Serilog.

And finally I added an enricher that adds some exception details:

```jsonc
{
  "@t": "2023-09-28T06:08:02.1008174Z",
  "@mt": "Unexpected Error while processing request to '{uri}'",
  "@l": "Error",
  "@x": "System.ArgumentNullException: Value cannot be null. (Parameter 'cancellationToken')\n   at async Task<IActionResult> Backbone.Modules.Challenges.ConsumerApi.Controllers.ChallengesController.Create(CancellationToken cancellationToken) in C:/Users/tnotheis/src/enmeshed/backbone_gh/bkb-backbone/Modules/Challenges/src/Challenges.ConsumerApi/Controllers/ChallengesController.cs:line 29\n   at async ValueTask<IActionResult> Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor+TaskOfIActionResultExecutor.Execute(ActionContext actionContext, IActionResultTypeMapper mapper, ObjectMethodExecutor executor, object controller, object[] arguments)\n   at async Task Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeActionMethodAsync()+Logged(?)\n   at async Task Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeNextActionFilterAsync()+Awaited(?)\n   at void Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)\n   at Task Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(ref State next, ref Scope scope, ref object state, ref bool isCompleted)\n   at Task Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()\n   at async Task Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeNextExceptionFilterAsync()+Awaited(?)",
  // ...
  "ExceptionDetail": {
    "Type": "System.ArgumentNullException",
    "HResult": -2147467261,
    "Message": "Value cannot be null. (Parameter 'cancellationToken')",
    "Source": "Backbone.Modules.Challenges.ConsumerApi",
    "StackTrace": "   at async Task<IActionResult> Backbone.Modules.Challenges.ConsumerApi.Controllers.ChallengesController.Create(CancellationToken cancellationToken) in C:/Users/tnotheis/src/enmeshed/backbone_gh/bkb-backbone/Modules/Challenges/src/Challenges.ConsumerApi/Controllers/ChallengesController.cs:line 29\n   at async ValueTask<IActionResult> Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor+TaskOfIActionResultExecutor.Execute(ActionContext actionContext, IActionResultTypeMapper mapper, ObjectMethodExecutor executor, object controller, object[] arguments)\n   at async Task Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeActionMethodAsync()+Logged(?)\n   at async Task Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeNextActionFilterAsync()+Awaited(?)\n   at void Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)\n   at Task Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(ref State next, ref Scope scope, ref object state, ref bool isCompleted)\n   at Task Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()\n   at async Task Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeNextExceptionFilterAsync()+Awaited(?)",
    "TargetSite": "Void MoveNext()",
    "ParamName": "cancellationToken"
  }
}
```

In the above log message, the property "ExceptionDetail" is the one added by the enricher. The only thing that's bothering me is that it duplicates the information in the default `@x` property. So if anyone has an idea how to get rid of the `@x`, please let me know.