### PR TITLE
Simplify aspnet logging

### DIFF
--- a/AdminUi/src/AdminUi/AdminUi.csproj
+++ b/AdminUi/src/AdminUi/AdminUi.csproj
@@ -36,6 +36,7 @@
         <PackageReference Include="Serilog.Exceptions.EntityFrameworkCore" Version="8.4.0" />
         <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
         <PackageReference Include="Serilog.Sinks.Http" Version="8.0.0" />
+        <PackageReference Include="Serilog.Sinks.Seq" Version="5.2.3" />
         <!-- CAUTION: Do not upgrade 'AspNetCore.HealthChecks.NpgSql' before the following issue is resolved: https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/issues/1993 -->
         <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="[6.0.2]" />
         <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="7.0.0" />

--- a/AdminUi/src/AdminUi/Program.cs
+++ b/AdminUi/src/AdminUi/Program.cs
@@ -80,7 +80,7 @@ static WebApplication CreateApp(string[] args)
     Configure(app);
 
     app.MigrateDbContext<AdminUiDbContext>();
-    
+
     return app;
 }
 
@@ -117,7 +117,8 @@ static void ConfigureServices(IServiceCollection services, IConfiguration config
             options
                 .UseEntityFrameworkCore()
                 .UseDbContext<DevicesDbContext>()
-                .ReplaceDefaultEntities<CustomOpenIddictEntityFrameworkCoreApplication, CustomOpenIddictEntityFrameworkCoreAuthorization, CustomOpenIddictEntityFrameworkCoreScope, CustomOpenIddictEntityFrameworkCoreToken, string>();
+                .ReplaceDefaultEntities<CustomOpenIddictEntityFrameworkCoreApplication, CustomOpenIddictEntityFrameworkCoreAuthorization, CustomOpenIddictEntityFrameworkCoreScope,
+                    CustomOpenIddictEntityFrameworkCoreToken, string>();
             options.AddApplicationStore<CustomOpenIddictEntityFrameworkCoreApplicationStore>();
         });
 

--- a/AdminUi/src/AdminUi/Program.cs
+++ b/AdminUi/src/AdminUi/Program.cs
@@ -26,36 +26,63 @@ Log.Logger = new LoggerConfiguration()
     .WriteTo.Console()
     .CreateBootstrapLogger();
 
-var builder = WebApplication.CreateBuilder(args);
-builder.WebHost
-    .UseKestrel(options =>
-    {
-        options.AddServerHeader = false;
-        options.Limits.MaxRequestBodySize = 20.Mebibytes();
-    });
+try
+{
+    Log.Information("Creating app...");
 
-LoadConfiguration(builder, args);
+    var app = CreateApp(args);
 
-builder.Host
-    .UseSerilog((context, configuration) => configuration
-        .ReadFrom.Configuration(context.Configuration, new ConfigurationReaderOptions { SectionName = "Logging" })
-        .Enrich.WithCorrelationId("X-Correlation-Id", addValueIfHeaderAbsence: true)
-        .Enrich.WithDemystifiedStackTraces()
-        .Enrich.FromLogContext()
-        .Enrich.WithProperty("service", "adminui")
-        .Enrich.WithExceptionDetails(new DestructuringOptionsBuilder()
-            .WithDefaultDestructurers()
-            .WithDestructurers(new[] { new DbUpdateExceptionDestructurer() })))
-    .UseServiceProviderFactory(new AutofacServiceProviderFactory());
+    Log.Information("App created.");
 
-ConfigureServices(builder.Services, builder.Configuration, builder.Environment);
+    Log.Information("Starting app...");
 
-var app = builder.Build();
-Configure(app);
+    app.Run();
 
-app.MigrateDbContext<AdminUiDbContext>();
+    return 0;
+}
+catch (Exception ex)
+{
+    Log.Fatal(ex, "Host terminated unexpectedly");
+    return 1;
+}
+finally
+{
+    Log.CloseAndFlush();
+}
 
-app.Run();
+static WebApplication CreateApp(string[] args)
+{
+    var builder = WebApplication.CreateBuilder(args);
+    builder.WebHost
+        .UseKestrel(options =>
+        {
+            options.AddServerHeader = false;
+            options.Limits.MaxRequestBodySize = 20.Mebibytes();
+        });
+
+    LoadConfiguration(builder, args);
+
+    builder.Host
+        .UseSerilog((context, configuration) => configuration
+            .ReadFrom.Configuration(context.Configuration, new ConfigurationReaderOptions { SectionName = "Logging" })
+            .Enrich.WithCorrelationId("X-Correlation-Id", addValueIfHeaderAbsence: true)
+            .Enrich.WithDemystifiedStackTraces()
+            .Enrich.FromLogContext()
+            .Enrich.WithProperty("service", "adminui")
+            .Enrich.WithExceptionDetails(new DestructuringOptionsBuilder()
+                .WithDefaultDestructurers()
+                .WithDestructurers(new[] { new DbUpdateExceptionDestructurer() })))
+        .UseServiceProviderFactory(new AutofacServiceProviderFactory());
+
+    ConfigureServices(builder.Services, builder.Configuration, builder.Environment);
+
+    var app = builder.Build();
+    Configure(app);
+
+    app.MigrateDbContext<AdminUiDbContext>();
+    
+    return app;
+}
 
 static void ConfigureServices(IServiceCollection services, IConfiguration configuration, IHostEnvironment environment)
 {

--- a/AdminUi/src/AdminUi/appsettings.json
+++ b/AdminUi/src/AdminUi/appsettings.json
@@ -32,7 +32,14 @@
     },
     "Logging": {
         "MinimumLevel": {
-            "Default": "Error"
+            "Default": "Warning",
+            "Override": {
+                "Backbone": "Information",
+                "Enmeshed": "Information",
+                "AdminUi": "Information",
+
+                "Microsoft": "Information"
+            }
         },
         "WriteTo": {
             "Console": {

--- a/AdminUi/src/AdminUi/appsettings.override.json
+++ b/AdminUi/src/AdminUi/appsettings.override.json
@@ -66,7 +66,22 @@
     },
     "Logging": {
         "MinimumLevel": {
-            "Default": "Information"
+            "Default": "Information",
+            "Override": {
+                "Backbone": "Debug",
+                "Enmeshed": "Debug",
+                "AdminUi": "Debug",
+
+                "Microsoft.AspNetCore": "Warning"
+            }
+        },
+        "WriteTo": {
+            "Seq": {
+                "Name": "Seq",
+                "Args": {
+                    "ServerUrl": "http://localhost:5341"
+                }
+            }
         }
     }
 }

--- a/Backbone.Infrastructure/Backbone.Infrastructure.csproj
+++ b/Backbone.Infrastructure/Backbone.Infrastructure.csproj
@@ -10,6 +10,8 @@
         <PackageReference Include="Autofac" Version="7.1.0" />
         <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
+        <PackageReference Include="Serilog" Version="3.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Backbone.Infrastructure/Logging/LogHelper.cs
+++ b/Backbone.Infrastructure/Logging/LogHelper.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.AspNetCore.Http;
+using Serilog;
+using Serilog.Events;
+
+namespace Backbone.Infrastructure.Logging;
+
+public static class LogHelper
+{
+    public static LogEventLevel GetLevel(HttpContext ctx, double _, Exception? ex)
+    {
+        return ex != null
+            ? LogEventLevel.Error
+            : ctx.Response.StatusCode > 499
+                ? LogEventLevel.Error
+                : IsHealthCheckEndpoint(ctx) // Not an error, check if it was a health check
+                    ? LogEventLevel.Verbose // Was a health check, use Verbose
+                    : LogEventLevel.Information;
+    }
+
+    private static bool IsHealthCheckEndpoint(HttpContext ctx)
+    {
+        var endpoint = ctx.GetEndpoint();
+        if (endpoint != null)
+        {
+            return string.Equals(
+                endpoint.DisplayName,
+                "Health checks",
+                StringComparison.Ordinal);
+        }
+
+        // No endpoint, so not a health check endpoint
+        return false;
+    }
+
+    public static void EnrichFromRequest(IDiagnosticContext diagnosticContext, HttpContext httpContext)
+    {
+        var request = httpContext.Request;
+
+        diagnosticContext.Set("Host", request.Host);
+        diagnosticContext.Set("Protocol", request.Protocol);
+        diagnosticContext.Set("Scheme", request.Scheme);
+
+        if (request.QueryString.HasValue)
+        {
+            diagnosticContext.Set("QueryString", request.QueryString.Value);
+        }
+
+        diagnosticContext.Set("ContentType", httpContext.Response.ContentType);
+
+        var endpoint = httpContext.GetEndpoint();
+        if (endpoint != null)
+        {
+            diagnosticContext.Set("EndpointName", endpoint.DisplayName);
+        }
+    }
+}

--- a/ConsumerApi/ConsumerApi.csproj
+++ b/ConsumerApi/ConsumerApi.csproj
@@ -41,6 +41,7 @@
 		<PackageReference Include="Serilog.Exceptions.EntityFrameworkCore" Version="8.4.0" />
 		<PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
 		<PackageReference Include="Serilog.Sinks.Http" Version="8.0.0" />
+        <PackageReference Include="Serilog.Sinks.Seq" Version="5.2.3" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/ConsumerApi/Program.cs
+++ b/ConsumerApi/Program.cs
@@ -40,6 +40,10 @@ using Serilog.Exceptions.Core;
 using Serilog.Exceptions.EntityFrameworkCore.Destructurers;
 using Serilog.Settings.Configuration;
 
+Log.Logger = new LoggerConfiguration()
+    .WriteTo.Console()
+    .CreateBootstrapLogger();
+
 var builder = WebApplication.CreateBuilder(args);
 builder.WebHost
     .UseKestrel(options =>

--- a/ConsumerApi/appsettings.json
+++ b/ConsumerApi/appsettings.json
@@ -79,7 +79,14 @@
     },
     "Logging": {
         "MinimumLevel": {
-            "Default": "Error"
+          "Default": "Warning",
+          "Override": {
+            "Backbone": "Information",
+            "Enmeshed": "Information",
+            "ConsumerApi": "Information",
+
+            "Microsoft": "Information",
+          }
         },
         "WriteTo": {
             "Console": {

--- a/ConsumerApi/appsettings.override.json
+++ b/ConsumerApi/appsettings.override.json
@@ -126,9 +126,24 @@
             }
         }
     },
-    "Logging": {
-        "MinimumLevel": {
-            "Default": "Information"
+  "Logging": {
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Backbone": "Debug",
+        "Enmeshed": "Debug",
+        "ConsumerApi": "Debug",
+
+        "Microsoft.AspNetCore": "Warning"
+      }
+    },
+    "WriteTo": {
+      "Seq": {
+        "Name": "Seq",
+        "Args": {
+          "ServerUrl": "http://seq:5341"
         }
+      }
     }
+  }
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Backbone
 
 [![GitHub Actions CI](https://github.com/nmshd/backbone/workflows/Publish/badge.svg)](https://github.com/nmshd/backbone/actions?query=workflow%3APublish)
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/enmeshed-backbone)](https://artifacthub.io/packages/helm/enmeshed-backbone/backbone-helm-chart)
 
 The Enmeshed Backbone embraces all central services required by the Enmeshed platform to work. It consists of the underlying infrastructure, its hosted services, and the libraries used within the services.
 

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -89,12 +89,23 @@ services:
     volumes:
       - rabbitmq-volume:/var/lib/rabbitmq # default data dir
 
+  seq:
+    image: datalust/seq:latest
+    ports:
+      - "8081:80"
+      - "5341:5341"
+    volumes:
+      - seq-data:/data
+    environment:
+      - ACCEPT_EULA=Y
+    restart: unless-stopped
+
   #elasticsearch:
   #  image: elasticsearch:${ELK_VERSION}
   #  container_name: elasticsearch
   #  restart: always
   #  volumes:
-  #    - elastic_data:/usr/share/elasticsearch/data/
+  #    - elastic-data:/usr/share/elasticsearch/data/
   #  environment:
   #    - xpack.watcher.enabled=false
   #    - xpack.security.enabled=false
@@ -138,4 +149,5 @@ volumes:
     external: true
   azure-storage-emulator-volume:
     external: true
-  elastic_data:
+  elastic-data:
+  seq-data:


### PR DESCRIPTION
# Readiness checklist

-   [ ] I added/updated unit tests.
-   [ ] I added/updated integration tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.

This PR includes the following:
* It mainly reduces the noise of ASP.NET Core default logs by reducing the log level to Warning and at the same time adding the `SerilogRequestLogging` middleware, which summarizes each request.
* I also added "Seq" for local development. Seq is a tool to view structured logs. I added it as a container to the docker-compose stack, so you can now access the logs on `locahost:8081`. 
* I also increased the default log level from Error to Warning, while overriding the default log level for our backbone internal logs to Information
* Finally, I surrounded the startup logic with a try catch block, and added some log statements to `catch` and `finally`, as this seems to be best practice.