### PR TITLE
HalfOfMonth variable not being used

### DIFF
--- a/Modules/Quotas/test/Quotas.Application.Tests/Tests/Repositories/MessagesRepositoryTests.cs
+++ b/Modules/Quotas/test/Quotas.Application.Tests/Tests/Repositories/MessagesRepositoryTests.cs
@@ -28,14 +28,7 @@ public class MessagesRepositoryTests
      * such as TOMORROW or YESTERDAY and be certain that those dates fall on the same Month.
      * </summary>
      */
-    private static readonly DateTime TODAY = new(
-        DateTime.UtcNow.Year,
-        DateTime.UtcNow.Month,
-        15,
-        DateTime.UtcNow.Hour,
-        DateTime.UtcNow.Minute,
-        DateTime.UtcNow.Second
-        );
+    private static readonly DateTime TODAY = new(2020, 02, 15, 10, 30, 00);
     private static readonly DateTime YESTERDAY = TODAY.AddDays(-1);
     private static readonly DateTime TOMORROW = TODAY.AddDays(1);
     private static readonly DateTime LAST_YEAR = TODAY.AddYears(-1);
@@ -48,6 +41,8 @@ public class MessagesRepositoryTests
         var connection = FakeDbContextFactory.CreateDbConnection();
         (_messagesArrangeContext, _, _) = FakeDbContextFactory.CreateDbContexts<MessagesDbContext>(connection);
         (_, _, _actContext) = FakeDbContextFactory.CreateDbContexts<QuotasDbContext>(connection);
+
+        SystemTime.Set(TODAY);
     }
 
     [Fact]
@@ -64,8 +59,6 @@ public class MessagesRepositoryTests
 
         var repository = new MessagesRepository(_actContext);
         const QuotaPeriod quotaPeriod = QuotaPeriod.Hour;
-
-        SystemTime.Set(TODAY);
 
         // Act
         var count = await repository.Count(_identityAddress1, quotaPeriod.CalculateBegin(), quotaPeriod.CalculateEnd(), CancellationToken.None);
@@ -144,6 +137,8 @@ public class MessagesRepositoryTests
 
     private static Message CreateMessage(DateTime createdAt, IdentityAddress identityAddress)
     {
+        var savedDateTime = SystemTime.UtcNow;
+
         SystemTime.Set(createdAt);
 
         var message = new Message(
@@ -155,7 +150,7 @@ public class MessagesRepositoryTests
             new List<RecipientInformation>()
             );
 
-        SystemTime.Reset();
+        SystemTime.Set(savedDateTime);
 
         return message;
     }

--- a/Modules/Quotas/test/Quotas.Application.Tests/Tests/Repositories/MessagesRepositoryTests.cs
+++ b/Modules/Quotas/test/Quotas.Application.Tests/Tests/Repositories/MessagesRepositoryTests.cs
@@ -21,7 +21,13 @@ public class MessagesRepositoryTests
     private readonly MessagesDbContext _messagesArrangeContext;
     private readonly QuotasDbContext _actContext;
 
-    private static readonly DateTime TODAY = new(DateTime.Now.Year, DateTime.Now.Month, 15);
+    /**
+     * <summary>
+     * TODAY is set to the 15th of the current month so that we can use notions
+     * such as TOMORROW or YESTERDAY and be certain that those dates fall on the same Month.
+     * </summary>
+     */
+    private static readonly DateTime TODAY = new(TODAY.Year, TODAY.Month, 15);
     private static readonly DateTime YESTERDAY = TODAY.AddDays(-1);
     private static readonly DateTime TOMORROW = TODAY.AddDays(1);
     private static readonly DateTime LAST_YEAR = TODAY.AddYears(-1);
@@ -41,7 +47,7 @@ public class MessagesRepositoryTests
     {
         // Arrange
         var messages = new List<Message>() {
-            CreateMessage(DateTime.Now, _identityAddress1),
+            CreateMessage(TODAY, _identityAddress1),
             CreateMessage(YESTERDAY, _identityAddress1),
             CreateMessage(TOMORROW, _identityAddress1)
         };
@@ -63,7 +69,7 @@ public class MessagesRepositoryTests
     {
         // Arrange
         var messages = new List<Message>() {
-            CreateMessage(DateTime.Now, _identityAddress1),
+            CreateMessage(TODAY, _identityAddress1),
             CreateMessage(YESTERDAY, _identityAddress1),
             CreateMessage(TOMORROW, _identityAddress1),
             CreateMessage(LAST_YEAR, _identityAddress1),
@@ -87,7 +93,7 @@ public class MessagesRepositoryTests
     {
         // Arrange
         var messages = new List<Message>() {
-            CreateMessage(DateTime.Now, _identityAddress1),
+            CreateMessage(TODAY, _identityAddress1),
             CreateMessage(TOMORROW, _identityAddress1),
             CreateMessage(NEXT_YEAR, _identityAddress1)
         };
@@ -109,7 +115,7 @@ public class MessagesRepositoryTests
     {
         // Arrange
         var messages = new List<Message>() {
-            CreateMessage(DateTime.Now, _identityAddress1),
+            CreateMessage(TODAY, _identityAddress1),
             CreateMessage(TOMORROW, _identityAddress2),
             CreateMessage(NEXT_YEAR, _identityAddress1)
         };

--- a/Modules/Quotas/test/Quotas.Application.Tests/Tests/Repositories/MessagesRepositoryTests.cs
+++ b/Modules/Quotas/test/Quotas.Application.Tests/Tests/Repositories/MessagesRepositoryTests.cs
@@ -27,7 +27,14 @@ public class MessagesRepositoryTests
      * such as TOMORROW or YESTERDAY and be certain that those dates fall on the same Month.
      * </summary>
      */
-    private static readonly DateTime TODAY = new(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 15);
+    private static readonly DateTime TODAY = new(
+        DateTime.UtcNow.Year,
+        DateTime.UtcNow.Month,
+        15,
+        DateTime.UtcNow.Hour,
+        DateTime.UtcNow.Minute,
+        DateTime.UtcNow.Second
+        );
     private static readonly DateTime YESTERDAY = TODAY.AddDays(-1);
     private static readonly DateTime TOMORROW = TODAY.AddDays(1);
     private static readonly DateTime LAST_YEAR = TODAY.AddYears(-1);

--- a/Modules/Quotas/test/Quotas.Application.Tests/Tests/Repositories/MessagesRepositoryTests.cs
+++ b/Modules/Quotas/test/Quotas.Application.Tests/Tests/Repositories/MessagesRepositoryTests.cs
@@ -14,7 +14,6 @@ using Xunit;
 namespace Backbone.Modules.Quotas.Application.Tests.Tests.Repositories;
 public class MessagesRepositoryTests
 {
-    private static readonly DateTime HALF_OF_MONTH = new(DateTime.Now.Year, DateTime.Now.Month, 15);
 
     private readonly IdentityAddress _identityAddress1 = TestDataGenerator.CreateRandomIdentityAddress();
     private readonly IdentityAddress _identityAddress2 = TestDataGenerator.CreateRandomIdentityAddress();
@@ -22,10 +21,11 @@ public class MessagesRepositoryTests
     private readonly MessagesDbContext _messagesArrangeContext;
     private readonly QuotasDbContext _actContext;
 
-    private static readonly DateTime YESTERDAY = HALF_OF_MONTH.AddDays(-1);
-    private static readonly DateTime TOMORROW = HALF_OF_MONTH.AddDays(1);
-    private static readonly DateTime LAST_YEAR = HALF_OF_MONTH.AddYears(-1);
-    private static readonly DateTime NEXT_YEAR = HALF_OF_MONTH.AddYears(1);
+    private static readonly DateTime TODAY = new(DateTime.Now.Year, DateTime.Now.Month, 15);
+    private static readonly DateTime YESTERDAY = TODAY.AddDays(-1);
+    private static readonly DateTime TOMORROW = TODAY.AddDays(1);
+    private static readonly DateTime LAST_YEAR = TODAY.AddYears(-1);
+    private static readonly DateTime NEXT_YEAR = TODAY.AddYears(1);
 
     public MessagesRepositoryTests()
     {

--- a/Modules/Quotas/test/Quotas.Application.Tests/Tests/Repositories/MessagesRepositoryTests.cs
+++ b/Modules/Quotas/test/Quotas.Application.Tests/Tests/Repositories/MessagesRepositoryTests.cs
@@ -14,16 +14,18 @@ using Xunit;
 namespace Backbone.Modules.Quotas.Application.Tests.Tests.Repositories;
 public class MessagesRepositoryTests
 {
+    private static readonly DateTime HALF_OF_MONTH = new(DateTime.Now.Year, DateTime.Now.Month, 15);
+
     private readonly IdentityAddress _identityAddress1 = TestDataGenerator.CreateRandomIdentityAddress();
     private readonly IdentityAddress _identityAddress2 = TestDataGenerator.CreateRandomIdentityAddress();
 
     private readonly MessagesDbContext _messagesArrangeContext;
     private readonly QuotasDbContext _actContext;
 
-    private static readonly DateTime YESTERDAY = DateTime.UtcNow.AddDays(-1);
-    private static readonly DateTime TOMORROW = DateTime.UtcNow.AddDays(1);
-    private static readonly DateTime LAST_YEAR = DateTime.UtcNow.AddYears(-1);
-    private static readonly DateTime NEXT_YEAR = DateTime.UtcNow.AddYears(1);
+    private static readonly DateTime YESTERDAY = HALF_OF_MONTH.AddDays(-1);
+    private static readonly DateTime TOMORROW = HALF_OF_MONTH.AddDays(1);
+    private static readonly DateTime LAST_YEAR = HALF_OF_MONTH.AddYears(-1);
+    private static readonly DateTime NEXT_YEAR = HALF_OF_MONTH.AddYears(1);
 
     public MessagesRepositoryTests()
     {
@@ -60,9 +62,6 @@ public class MessagesRepositoryTests
     public async Task Counts_entities_within_timeframe_month_quotaPeriod()
     {
         // Arrange
-        var halfOfMonth = new DateTime(DateTime.Now.Year, DateTime.Now.Month, 15);
-        SystemTime.Set(halfOfMonth);
-
         var messages = new List<Message>() {
             CreateMessage(DateTime.Now, _identityAddress1),
             CreateMessage(YESTERDAY, _identityAddress1),

--- a/Modules/Quotas/test/Quotas.Application.Tests/Tests/Repositories/MessagesRepositoryTests.cs
+++ b/Modules/Quotas/test/Quotas.Application.Tests/Tests/Repositories/MessagesRepositoryTests.cs
@@ -1,6 +1,7 @@
 ﻿using Backbone.DevelopmentKit.Identity.ValueObjects;
 using Backbone.Modules.Messages.Domain.Entities;
 using Backbone.Modules.Messages.Infrastructure.Persistence.Database;
+using Backbone.Modules.Quotas.Domain.Aggregates;
 using Backbone.Modules.Quotas.Domain.Aggregates.Identities;
 using Backbone.Modules.Quotas.Infrastructure.Persistence.Database;
 using Backbone.Modules.Quotas.Infrastructure.Persistence.Repository;
@@ -63,6 +64,8 @@ public class MessagesRepositoryTests
 
         var repository = new MessagesRepository(_actContext);
         const QuotaPeriod quotaPeriod = QuotaPeriod.Hour;
+
+        SystemTime.Set(TODAY);
 
         // Act
         var count = await repository.Count(_identityAddress1, quotaPeriod.CalculateBegin(), quotaPeriod.CalculateEnd(), CancellationToken.None);

--- a/Modules/Quotas/test/Quotas.Application.Tests/Tests/Repositories/MessagesRepositoryTests.cs
+++ b/Modules/Quotas/test/Quotas.Application.Tests/Tests/Repositories/MessagesRepositoryTests.cs
@@ -27,7 +27,7 @@ public class MessagesRepositoryTests
      * such as TOMORROW or YESTERDAY and be certain that those dates fall on the same Month.
      * </summary>
      */
-    private static readonly DateTime TODAY = new(TODAY.Year, TODAY.Month, 15);
+    private static readonly DateTime TODAY = new(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 15);
     private static readonly DateTime YESTERDAY = TODAY.AddDays(-1);
     private static readonly DateTime TOMORROW = TODAY.AddDays(1);
     private static readonly DateTime LAST_YEAR = TODAY.AddYears(-1);


### PR DESCRIPTION
# Readiness checklist

-   [x] I added/updated unit tests.
-   [ ] I added/updated integration tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.

# Description
When the `Counts_entities_within_timeframe_month_quotaPeriod` test was developed, we attempted to pivot all dates around the 15th of the current month so that we could use notions such as _Tomorrow_ or _Yesterday_ and be certain that those dates would fall on the same Month. Turns out that this was not done properly, which led to errors when running this test on the last/first day of each month.

trivia: The commit is dated from October 31st, but it was actually done about the same time as this PR. Changing the system date for debugging had such a side-effect, i.e., I committed my changes before setting the clock to the right date again.