### PR TITLE
Configuration of dependabot for npm packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,6 @@
 version: 2
 updates:
+  ##### NuGet packages for Backbone.sln #####
   - package-ecosystem: "nuget"
     directory: "/"
     schedule:
@@ -16,6 +17,7 @@ updates:
     labels:
       - "dependencies"
 
+  ##### GitHub Actions #####
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -29,8 +31,88 @@ updates:
     labels:
       - "dependencies"
 
+  ##### Admin UI Angular App #####
   - package-ecosystem: "npm"
-    directory: "/"
+    directory: "/AdminUi/src/AdminUi/ClientApp"
+    schedule:
+      interval: "weekly"
+    groups:
+      update-npm-dependencies:
+        patterns:
+          - "*"
+    reviewers:
+      - "tnotheis"
+    labels:
+      - "dependencies"
+
+  ##### Performance Tests #####
+  - package-ecosystem: "npm"
+    directory: /Modules/Challenges/test/Challenges.API.Tests.Performance.EndToEnd
+    schedule:
+      interval: "weekly"
+    groups:
+      update-npm-dependencies:
+        patterns:
+          - "*"
+    reviewers:
+      - "tnotheis"
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "npm"
+    directory: /Modules/Files/test/Files.API.Tests.Performance.EndToEnd
+    schedule:
+      interval: "weekly"
+    groups:
+      update-npm-dependencies:
+        patterns:
+          - "*"
+    reviewers:
+      - "tnotheis"
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "npm"
+    directory: /Modules/Challenges/test/Challenges.API.Tests.Performance.EndToEnd
+    schedule:
+      interval: "weekly"
+    groups:
+      update-npm-dependencies:
+        patterns:
+          - "*"
+    reviewers:
+      - "tnotheis"
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "npm"
+    directory: /Modules/Messages/test/Messages.API.Tests.Performance.EndToEnd
+    schedule:
+      interval: "weekly"
+    groups:
+      update-npm-dependencies:
+        patterns:
+          - "*"
+    reviewers:
+      - "tnotheis"
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "npm"
+    directory: /Modules/Relationships/test/Relationships.API.Tests.Performance.EndToEnd
+    schedule:
+      interval: "weekly"
+    groups:
+      update-npm-dependencies:
+        patterns:
+          - "*"
+    reviewers:
+      - "tnotheis"
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "npm"
+    directory: /Modules/Tokens/test/Tokens.API.Tests.Performance.EndToEnd
     schedule:
       interval: "weekly"
     groups:


### PR DESCRIPTION
# Readiness checklist

-   [ ] I added/updated unit tests.
-   [ ] I added/updated integration tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.

The previous configuration wasn't correct. I incorrectly assumed that when setting the directory to "/", it would use all package.json files in the whole repository. But it only uses package.json files directly in the specified directory. This is a temporary solution until https://github.com/dependabot/dependabot-core/issues/2178 is resolved.