### PR TITLE
Update Postgres healthcheck package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,6 @@ updates:
         patterns:
           - "*"
         exclude-patterns:
-          - "AspNetCore.HealthChecks.NpgSql"
           - "Npgsql.EntityFrameworkCore.PostgreSQL"
     reviewers:
       - "tnotheis"

--- a/AdminUi/src/AdminUi/AdminUi.csproj
+++ b/AdminUi/src/AdminUi/AdminUi.csproj
@@ -35,7 +35,7 @@
         <PackageReference Include="Serilog.Sinks.Http" Version="8.0.0" />
         <PackageReference Include="Serilog.Sinks.Seq" Version="5.2.3" />
         <!-- CAUTION: Do not upgrade 'AspNetCore.HealthChecks.NpgSql' before the following issue is resolved: https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/issues/1993 -->
-        <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="[6.0.2]" />
+        <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="7.1.0" />
         <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="7.0.0" />
     </ItemGroup>
 

--- a/AdminUi/src/AdminUi/Extensions/IServiceCollectionExtensions.cs
+++ b/AdminUi/src/AdminUi/Extensions/IServiceCollectionExtensions.cs
@@ -139,7 +139,7 @@ public static class IServiceCollectionExtensions
                     break;
                 case "Postgres":
                     services.AddHealthChecks().AddNpgSql(
-                        npgsqlConnectionString: connectionString,
+                        connectionString: connectionString,
                         name: moduleName);
                     break;
                 default:

--- a/BuildingBlocks/src/BuildingBlocks.API/BuildingBlocks.API.csproj
+++ b/BuildingBlocks/src/BuildingBlocks.API/BuildingBlocks.API.csproj
@@ -5,8 +5,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<!-- CAUTION: Do not upgrade 'AspNetCore.HealthChecks.NpgSql' before the following issue is resolved: https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/issues/1993 -->
-		<PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="[6.0.2]" />
+		<PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="7.1.0" />
 		<PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="7.0.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.13" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.13" />

--- a/BuildingBlocks/src/BuildingBlocks.API/Extensions/ServiceCollectionExtensions.cs
+++ b/BuildingBlocks/src/BuildingBlocks.API/Extensions/ServiceCollectionExtensions.cs
@@ -24,7 +24,7 @@ public static class ServiceCollectionExtensions
                 break;
             case "Postgres":
                 services.AddHealthChecks().AddNpgSql(
-                    npgsqlConnectionString: connectionString,
+                    connectionString: connectionString,
                     name: name);
                 break;
             default:


### PR DESCRIPTION
# Readiness checklist

-   [ ] I added/updated unit tests.
-   [ ] I added/updated integration tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.

There was a [bug](https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/issues/1993) in version 7.0.0 of the library that didn't allow us to update the package. Today it was finally fixed, so we can update to the latest version again.
I also unignored the package in the dependabot configuration, so that it's automatically updated again.