### PR TITLE
Identities Overview pagination buttons are disabled

### DIFF
--- a/AdminUi/src/AdminUi/ClientApp/src/app/components/shared/identities-overview/identities-overview.component.ts
+++ b/AdminUi/src/AdminUi/ClientApp/src/app/components/shared/identities-overview/identities-overview.component.ts
@@ -162,7 +162,7 @@ export class IdentitiesOverviewComponent {
         this.identityService.getIdentities(this.filter, this.pageIndex, this.pageSize).subscribe({
             next: (data: ODataResponse<IdentityOverview[]>) => {
                 this.identities = data.value;
-                this.totalRecords = data.value.length;
+                this.totalRecords = data["@odata.count"];
             },
             complete: () => (this.loading = false),
             error: (err: any) => {

--- a/AdminUi/src/AdminUi/ClientApp/src/app/services/identity-service/identity.service.ts
+++ b/AdminUi/src/AdminUi/ClientApp/src/app/services/identity-service/identity.service.ts
@@ -59,19 +59,19 @@ export class IdentityService {
         if (filter.createdAt.operator !== undefined && filter.createdAt.value !== undefined) {
             switch (filter.createdAt.operator) {
                 case ">":
-                    odataFilter.gt("createdAt", filter.createdAt.value);
+                    odataFilter.gt("createdAt", filter.createdAt.value.toISOString().slice(0, 10), false);
                     break;
                 case "<":
-                    odataFilter.lt("createdAt", filter.createdAt.value);
+                    odataFilter.lt("createdAt", filter.createdAt.value.toISOString().slice(0, 10), false);
                     break;
                 case "=":
-                    odataFilter.eq("createdAt", filter.createdAt.value);
+                    odataFilter.eq("createdAt", filter.createdAt.value.toISOString().slice(0, 10), false);
                     break;
                 case "<=":
-                    odataFilter.le("createdAt", filter.createdAt.value);
+                    odataFilter.le("createdAt", filter.createdAt.value.toISOString().slice(0, 10), false);
                     break;
                 case ">=":
-                    odataFilter.ge("createdAt", filter.createdAt.value);
+                    odataFilter.ge("createdAt", filter.createdAt.value.toISOString().slice(0, 10), false);
                     break;
                 default:
                     this.logger.error(`Invalid createdAt filter operator: ${filter.createdAt.operator}`);
@@ -82,19 +82,19 @@ export class IdentityService {
         if (filter.lastLoginAt.operator !== undefined && filter.lastLoginAt.value !== undefined) {
             switch (filter.lastLoginAt.operator) {
                 case ">":
-                    odataFilter.gt("lastLoginAt", filter.lastLoginAt.value);
+                    odataFilter.gt("lastLoginAt", filter.lastLoginAt.value.toISOString().slice(0, 10), false);
                     break;
                 case "<":
-                    odataFilter.lt("lastLoginAt", filter.lastLoginAt.value);
+                    odataFilter.lt("lastLoginAt", filter.lastLoginAt.value.toISOString().slice(0, 10), false);
                     break;
                 case "=":
-                    odataFilter.eq("lastLoginAt", filter.lastLoginAt.value);
+                    odataFilter.eq("lastLoginAt", filter.lastLoginAt.value.toISOString().slice(0, 10), false);
                     break;
                 case "<=":
-                    odataFilter.le("lastLoginAt", filter.lastLoginAt.value);
+                    odataFilter.le("lastLoginAt", filter.lastLoginAt.value.toISOString().slice(0, 10), false);
                     break;
                 case ">=":
-                    odataFilter.ge("lastLoginAt", filter.lastLoginAt.value);
+                    odataFilter.ge("lastLoginAt", filter.lastLoginAt.value.toISOString().slice(0, 10), false);
                     break;
                 default:
                     this.logger.error(`Invalid lastLoginAt filter operator: ${filter.lastLoginAt.operator}`);

--- a/AdminUi/src/AdminUi/ClientApp/src/app/services/identity-service/identity.service.ts
+++ b/AdminUi/src/AdminUi/ClientApp/src/app/services/identity-service/identity.service.ts
@@ -27,7 +27,7 @@ export class IdentityService {
     }
 
     public getIdentities(filter: IdentityOverviewFilter, pageNumber: number, pageSize: number): Observable<ODataResponse<IdentityOverview[]>> {
-        const paginationFilter = `$top=${pageSize}&$skip=${pageNumber}`;
+        const paginationFilter = `$top=${pageSize}&$skip=${pageNumber * pageSize}&$count=true`;
         return this.http.get<ODataResponse<IdentityOverview[]>>(`${this.odataUrl}${this.buildODataFilter(filter, paginationFilter)}${this.buildODataExpand()}`);
     }
 

--- a/AdminUi/src/AdminUi/ClientApp/src/app/utils/odata-response.ts
+++ b/AdminUi/src/AdminUi/ClientApp/src/app/utils/odata-response.ts
@@ -1,3 +1,5 @@
 export interface ODataResponse<Type> {
     value: Type;
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    "@odata.count": number;
 }


### PR DESCRIPTION
# Readiness checklist

-   [ ] I added/updated unit tests.
-   [ ] I added/updated integration tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.

# Details

- The issue with the Identities pagination was that the `totalRecords` count was set to length of the OData response. Even if the total count of Identities exceeded the `pageSize` value, the table would always assume there were no more Identities.
We can include a `$count=true` in the OData filter that returns an `@odata.count` property with the `totalRecords` value.

- `$skip` also doesn't take into consideration the page size, so we needed to multiply the `pageSize` by the `pageNumber` to get this value.

- Finally, there were some issues with the date filtering, instead of focusing only on the date, the filtering also included the time, so the equals filter didn't work properly. By converting the dates into a string using the ISO standard, used by OData, and removing the time from the string, we also fix this issue.