### PR TITLE
Uncatched NotFoundException on relationships BlobStorage migration

### DIFF
--- a/ConsumerApi/RelationshipsDbContextSeeder.cs
+++ b/ConsumerApi/RelationshipsDbContextSeeder.cs
@@ -48,9 +48,17 @@ public class RelationshipsDbContextSeeder : IDbSeeder<RelationshipsDbContext>
         {
             if (relationshipChange.Request.Content == null)
             {
-                var blobRequestContent = await _blobStorage!.FindAsync(_blobRootFolder!, $"{relationshipChange.Request.Id}_Req");
-                relationshipChange.Request.LoadContent(blobRequestContent);
-                context.RelationshipChanges.Update(relationshipChange);
+                try
+                {
+                    var blobRequestContent = await _blobStorage!.FindAsync(_blobRootFolder!, $"{relationshipChange.Request.Id}_Req");
+                    relationshipChange.Request.LoadContent(blobRequestContent);
+                    context.RelationshipChanges.Update(relationshipChange);
+                }
+                catch (NotFoundException)
+                {
+                    // due to missing validation, it was possible to create a relationship creation change without request content;
+                    // therefore we cannot tell whether this exception is an error or not
+                }
             }
 
             if (relationshipChange.Response is { Content: null })

--- a/Modules/Relationships/src/Relationships.Application/Relationships/Commands/CreateRelationship/Handler.cs
+++ b/Modules/Relationships/src/Relationships.Application/Relationships/Commands/CreateRelationship/Handler.cs
@@ -30,7 +30,6 @@ public class Handler : IRequestHandler<CreateRelationshipCommand, CreateRelation
         _eventBus = eventBus;
     }
 
-
     public async Task<CreateRelationshipResponse> Handle(CreateRelationshipCommand request, CancellationToken cancellationToken)
     {
         _cancellationToken = cancellationToken;


### PR DESCRIPTION
# Readiness checklist

-   [ ] I added/updated unit tests.
-   [ ] I added/updated integration tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.

Turns out there are cases where the content of a Relationship Creation Change Request is null. Therefore we have to catch all NotFoundExceptions when migrating.