### PR TITLE
Identity deletion process started event fails

### DIFF
--- a/Modules/Devices/src/Devices.Application/Identities/Commands/StartDeletionProcessAsSupport/Handler.cs
+++ b/Modules/Devices/src/Devices.Application/Identities/Commands/StartDeletionProcessAsSupport/Handler.cs
@@ -25,7 +25,7 @@ public class Handler : IRequestHandler<StartDeletionProcessAsSupportCommand, Sta
 
         await _identitiesRepository.Update(identity, cancellationToken);
 
-        _eventBus.Publish(new IdentityDeletionProcessStartedIntegrationEvent(identity, deletionProcess));
+        _eventBus.Publish(new IdentityDeletionProcessStartedIntegrationEvent(identity.Address, deletionProcess.Id));
 
         return new StartDeletionProcessAsSupportResponse(deletionProcess);
     }

--- a/Modules/Devices/src/Devices.Application/IntegrationEvents/Outgoing/IdentityDeletionProcessStartedIntegrationEvent.cs
+++ b/Modules/Devices/src/Devices.Application/IntegrationEvents/Outgoing/IdentityDeletionProcessStartedIntegrationEvent.cs
@@ -1,14 +1,13 @@
 ﻿using Backbone.BuildingBlocks.Application.Abstractions.Infrastructure.EventBus.Events;
-using Backbone.Modules.Devices.Domain.Entities.Identities;
 
 namespace Backbone.Modules.Devices.Application.IntegrationEvents.Outgoing;
 
 public class IdentityDeletionProcessStartedIntegrationEvent : IntegrationEvent
 {
-    public IdentityDeletionProcessStartedIntegrationEvent(Identity identity, IdentityDeletionProcess deletionProcess) : base($"{identity.Address}/DeletionProcessStarted/{deletionProcess.Id}")
+    public IdentityDeletionProcessStartedIntegrationEvent(string identityAddress, string deletionProcessId) : base($"{identityAddress}/DeletionProcessStarted/{deletionProcessId}")
     {
-        DeletionProcessId = deletionProcess.Id;
-        Address = identity.Address;
+        DeletionProcessId = deletionProcessId;
+        Address = identityAddress;
     }
 
     public string Address { get; }

--- a/Modules/Devices/src/Devices.Application/IntegrationEvents/Outgoing/IdentityDeletionProcessStartedIntegrationEvent.cs
+++ b/Modules/Devices/src/Devices.Application/IntegrationEvents/Outgoing/IdentityDeletionProcessStartedIntegrationEvent.cs
@@ -10,6 +10,6 @@ public class IdentityDeletionProcessStartedIntegrationEvent : IntegrationEvent
         Address = identityAddress;
     }
 
-    public string Address { get; }
-    public string DeletionProcessId { get; }
+    public string Address { get; private set; }
+    public string DeletionProcessId { get; private set; }
 }

--- a/Modules/Devices/test/Devices.Application.Tests/Tests/Identities/IntegrationEvents/IdentityDeletionProcessStartedIntegrationEventHandlerTests.cs
+++ b/Modules/Devices/test/Devices.Application.Tests/Tests/Identities/IntegrationEvents/IdentityDeletionProcessStartedIntegrationEventHandlerTests.cs
@@ -17,7 +17,7 @@ public class IdentityDeletionProcessStartedIntegrationEventHandlerTests
         var mockPushNotificationSender = A.Fake<IPushNotificationSender>();
         var handler = new IdentityDeletionProcessStartedIntegrationEventHandler(mockPushNotificationSender);
         var identity = TestDataGenerator.CreateIdentity();
-        var identityDeletionProcessStartedIntegrationEvent = new IdentityDeletionProcessStartedIntegrationEvent(identity, IdentityDeletionProcess.StartAsSupport(identity.Address));
+        var identityDeletionProcessStartedIntegrationEvent = new IdentityDeletionProcessStartedIntegrationEvent(identity.Address, IdentityDeletionProcess.StartAsSupport(identity.Address).Id);
 
         // Act
         await handler.Handle(identityDeletionProcessStartedIntegrationEvent);

--- a/Modules/Synchronization/src/Synchronization.Application/IntegrationEvents/Incoming/IdentityDeletionProcessStarted/IdentityDeletionProcessStartedIntegrationEvent.cs
+++ b/Modules/Synchronization/src/Synchronization.Application/IntegrationEvents/Incoming/IdentityDeletionProcessStarted/IdentityDeletionProcessStartedIntegrationEvent.cs
@@ -10,6 +10,6 @@ public class IdentityDeletionProcessStartedIntegrationEvent : IntegrationEvent
         Address = identityAddress;
     }
 
-    public string Address { get; }
-    public string DeletionProcessId { get; }
+    public string Address { get; private set; }
+    public string DeletionProcessId { get; private set; }
 }


### PR DESCRIPTION
# Readiness checklist

-   [X] I added/updated unit tests.
-   [ ] I added/updated integration tests.
-   [X] I ensured that the PR title is good enough for the changelog.
-   [X] I labeled the PR.

Similar issue to the one we had with the quotas (using the same event as outgoing and incoming).
The event can only use primitive types as parameters.
Also added private setters to avoid deserialization errors.