### PR TITLE
Use non-root users in Dockerfiles

### DIFF
--- a/.ci/docker-compose.test.yml
+++ b/.ci/docker-compose.test.yml
@@ -9,7 +9,7 @@ services:
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
     ports:
-      - "5000:80"
+      - "5000:8080"
     depends_on:
       database:
         condition: service_started
@@ -20,7 +20,7 @@ services:
       azure-storage-emulator:
         condition: service_started
     healthcheck:
-      test: ["CMD", "wget", "http://localhost/health"]
+      test: ["CMD", "wget", "http://localhost:8080/health"]
       interval: 5s
       timeout: 2s
       retries: 40
@@ -37,7 +37,7 @@ services:
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
     ports:
-      - "5173:80"
+      - "5173:8080"
     depends_on:
       database:
         condition: service_started

--- a/.ci/docker-compose.test.yml
+++ b/.ci/docker-compose.test.yml
@@ -20,7 +20,7 @@ services:
       azure-storage-emulator:
         condition: service_started
     healthcheck:
-      test: ["CMD", "wget", "http://localhost:8080/health"]
+      test: ["CMD", "wget", "http://localhost:8080/health", "-O", "/dev/null"]
       interval: 5s
       timeout: 2s
       retries: 40

--- a/AdminUi/src/AdminUi/Dockerfile
+++ b/AdminUi/src/AdminUi/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
-EXPOSE 80
+EXPOSE 8080
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 

--- a/AdminUi/src/AdminUi/Dockerfile
+++ b/AdminUi/src/AdminUi/Dockerfile
@@ -50,8 +50,11 @@ RUN dotnet publish /property:WarningLevel=0 /p:UseAppHost=false --no-restore --c
 
 FROM base AS final
 
-ENV ASPNETCORE_URLS=http://0.0.0.0:80
-
 WORKDIR /app
 COPY --from=publish /app/publish .
+
+ENV ASPNETCORE_URLS=http://0.0.0.0:8080
+
+USER $APP_UID
+
 ENTRYPOINT ["dotnet", "Backbone.AdminUi.dll"]

--- a/AdminUi/src/AdminUi/Dockerfile.debug
+++ b/AdminUi/src/AdminUi/Dockerfile.debug
@@ -3,6 +3,6 @@ EXPOSE 80
 
 WORKDIR /app
 
-ENV ASPNETCORE_URLS=http://0.0.0.0:80
+ENV ASPNETCORE_URLS=http://0.0.0.0:8080
 
 ENTRYPOINT ["dotnet", "watch", "--non-interactive", "--project", "AdminUi/src/AdminUi/AdminUi.csproj"]

--- a/AdminUi/src/AdminUi/Dockerfile.debug
+++ b/AdminUi/src/AdminUi/Dockerfile.debug
@@ -1,5 +1,5 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0
-EXPOSE 80
+EXPOSE 8080
 
 WORKDIR /app
 

--- a/ConsumerApi/Dockerfile
+++ b/ConsumerApi/Dockerfile
@@ -9,7 +9,7 @@ RUN dotnet publish /property:WarningLevel=0 --configuration Release --output /ap
 
 # Run
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine3.18
-EXPOSE 80
+EXPOSE 8080
 WORKDIR /app
 
 ENV Logging__Console__FormatterName=

--- a/ConsumerApi/Dockerfile
+++ b/ConsumerApi/Dockerfile
@@ -12,13 +12,15 @@ FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine3.18
 EXPOSE 80
 WORKDIR /app
 
-ENV ASPNETCORE_URLS=http://0.0.0.0:80
-
 ENV Logging__Console__FormatterName=
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=0
 RUN apk add icu-libs
 COPY --from=build-env /app .
 
 LABEL org.opencontainers.image.source = "https://github.com/nmshd/backbone"
+
+ENV ASPNETCORE_URLS=http://0.0.0.0:8080
+
+USER $APP_UID
 
 ENTRYPOINT ["dotnet", "Backbone.ConsumerApi.dll"]

--- a/ConsumerApi/Dockerfile.debug
+++ b/ConsumerApi/Dockerfile.debug
@@ -4,6 +4,6 @@ EXPOSE 80
 
 WORKDIR /app
 
-ENV ASPNETCORE_URLS=http://0.0.0.0:80
+ENV ASPNETCORE_URLS=http://0.0.0.0:8080
 
 ENTRYPOINT ["dotnet", "watch", "--non-interactive", "--project", "ConsumerApi/ConsumerApi.csproj"]

--- a/ConsumerApi/Dockerfile.debug
+++ b/ConsumerApi/Dockerfile.debug
@@ -1,6 +1,6 @@
 ﻿FROM mcr.microsoft.com/dotnet/sdk:8.0
 
-EXPOSE 80
+EXPOSE 8080
 
 WORKDIR /app
 

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - Modules__Synchronization__Infrastructure__BlobStorage__ConnectionInfo=${ENMESHED_BLOB_STORAGE_CONNECTION_STRING} # set this environment variable on your local system to an appropriate value (DefaultEndpointsProtocol=https;AccountName=<account-name>;AccountKey=<account-key>;EndpointSuffix=core.windows.net)
 
     ports:
-      - "8080:80"
+      - "8080:8080"
     depends_on:
       # - ms-sql-server
       - rabbitmq
@@ -102,7 +102,7 @@ services:
     environment:
       - ASPNETCORE_ENVIRONMENT=Local
     ports:
-      - "5173:80"
+      - "5173:8080"
     depends_on:
       # - ms-sql-server
       - rabbitmq

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -44,7 +44,7 @@ consumerapi:
 
   service:
     type: "ClusterIP"
-    port: 80
+    port: 8080
     loadBalancer:
       # ip - the static ip address the LoadBalancer should use
       ip: ""
@@ -119,7 +119,7 @@ adminui:
 
   service:
     type: "ClusterIP"
-    port: 80
+    port: 8080
 
   image:
     repository: "ghcr.io/nmshd/backbone-admin-ui"


### PR DESCRIPTION
# Readiness checklist

-   [ ] I added/updated unit tests.
-   [ ] I added/updated integration tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.

This PR changes the user within the containers of Consumer API and Admin UI to the non-root `app` user. Since this user does not have root permissions, it cannot start the applications on port 80, which is why I changed the default port to 8080. I also updated the Kubernetes services so that they point to the correct ports.