### PR TITLE
Consumer API: internal server error on register for push notifications when environment is passed

### DIFF
--- a/Modules/Devices/src/Devices.Application/PushNotifications/Commands/UpdateDeviceRegistration/UpdateDeviceRegistrationCommand.cs
+++ b/Modules/Devices/src/Devices.Application/PushNotifications/Commands/UpdateDeviceRegistration/UpdateDeviceRegistrationCommand.cs
@@ -1,5 +1,4 @@
-﻿using Backbone.Modules.Devices.Domain.Aggregates.PushNotifications;
-using MediatR;
+﻿using MediatR;
 
 namespace Backbone.Modules.Devices.Application.PushNotifications.Commands.UpdateDeviceRegistration;
 

--- a/Modules/Devices/src/Devices.Application/PushNotifications/Commands/UpdateDeviceRegistration/UpdateDeviceRegistrationValidator.cs
+++ b/Modules/Devices/src/Devices.Application/PushNotifications/Commands/UpdateDeviceRegistration/UpdateDeviceRegistrationValidator.cs
@@ -11,7 +11,7 @@ public class UpdateDeviceRegistrationValidator : AbstractValidator<UpdateDeviceR
     {
         RuleFor(dto => dto.Platform).In("fcm", "apns");
 
-        RuleFor(dto => dto.Environment).In("Development", "Production", null);
+        RuleFor(dto => dto.Environment).In("Development", "Production").When(dto => dto.Environment != null);
 
         RuleFor(dto => dto.Handle)
             .DetailedNotEmpty()


### PR DESCRIPTION
# Readiness checklist

-   [ ] I added/updated unit tests.
-   [ ] I added/updated integration tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.
