### PR TITLE
Consumer API: error during migration when multiple Datawallet Modifications with the same blob reference exist

### DIFF
--- a/ConsumerApi/SynchronizationDbContextSeeder.cs
+++ b/ConsumerApi/SynchronizationDbContextSeeder.cs
@@ -111,6 +111,7 @@ public class SynchronizationDbContextSeeder : IDbSeeder<SynchronizationDbContext
             {
                 var blobContent = await _blobStorage!.FindAsync(_blobRootFolder!, modification.Id);
                 modification.LoadEncryptedPayload(blobContent);
+                return true;
             }
             catch (NotFoundException)
             {
@@ -128,7 +129,8 @@ public class SynchronizationDbContextSeeder : IDbSeeder<SynchronizationDbContext
 
         if (!blob.TryGetValue(modification.Index, out var payload))
         {
-            _logger.LogInformation("Blob with Id '{id}' not found in blob reference. As the encrypted payload of a datawallet modification is not required, this is probably not an error.", modification.Id);
+            _logger.LogInformation("Blob with Id '{id}' not found in blob reference. As the encrypted payload of a datawallet modification is not required, this is probably not an error.",
+                modification.Id);
             return false;
         }
 

--- a/ConsumerApi/SynchronizationDbContextSeeder.cs
+++ b/ConsumerApi/SynchronizationDbContextSeeder.cs
@@ -39,7 +39,6 @@ public class SynchronizationDbContextSeeder : IDbSeeder<SynchronizationDbContext
 
         var hasMorePages = true;
 
-
         while (hasMorePages)
         {
             var modificationsWithoutEncryptedPayload = context.DatawalletModifications
@@ -52,6 +51,7 @@ public class SynchronizationDbContextSeeder : IDbSeeder<SynchronizationDbContext
             var blobReferences = modificationsWithoutEncryptedPayload
                 .Where(m => !string.IsNullOrWhiteSpace(m.BlobReference))
                 .Select(m => m.BlobReference)
+                .Distinct()
                 .ToList();
 
             var blobsFromReferences = await FindBlobsByReferences(blobReferences);


### PR DESCRIPTION
# Readiness checklist

-   [ ] I added/updated unit tests.
-   [ ] I added/updated integration tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.
