### PR TITLE
buildContainerImage scripts incorrectly escape part of buildx command

### DIFF
--- a/.ci/acli/buildContainerImage.js
+++ b/.ci/acli/buildContainerImage.js
@@ -6,6 +6,6 @@ import { getRequiredEnvVar } from "../lib.js";
 const tag = getRequiredEnvVar("TAG");
 
 const platforms = process.env.PLATFORMS ?? "linux/amd64,linux/arm64";
-const push = process.env.PUSH === "1" ? "--push --provenance=true --sbom=true" : "";
+const push = process.env.PUSH === "1" ? ["--push", "--provenance=true", "--sbom=true"] : "";
 
 await $`docker buildx build --file ./Modules/Devices/src/Devices.AdminCli/Dockerfile --tag ghcr.io/nmshd/backbone-admin-cli:${tag} --platform ${platforms} ${push} .`;

--- a/.ci/aui/buildContainerImage.js
+++ b/.ci/aui/buildContainerImage.js
@@ -6,6 +6,6 @@ import { getRequiredEnvVar } from "../lib.js";
 const tag = getRequiredEnvVar("TAG");
 
 const platforms = process.env.PLATFORMS ?? "linux/amd64,linux/arm64";
-const push = process.env.PUSH === "1" ? "--push --provenance=true --sbom=true" : "";
+const push = process.env.PUSH === "1" ? ["--push", "--provenance=true", "--sbom=true"] : "";
 
 await $`docker buildx build --file ./AdminUi/src/AdminUi/Dockerfile --tag ghcr.io/nmshd/backbone-admin-ui:${tag} --platform ${platforms} ${push} .`;

--- a/.ci/capi/buildContainerImage.js
+++ b/.ci/capi/buildContainerImage.js
@@ -6,6 +6,6 @@ import { getRequiredEnvVar } from "../lib.js";
 const tag = getRequiredEnvVar("TAG");
 
 const platforms = process.env.PLATFORMS ?? "linux/amd64,linux/arm64";
-const push = process.env.PUSH === "1" ? "--push --provenance=true --sbom=true" : "";
+const push = process.env.PUSH === "1" ? ["--push", "--provenance=true", "--sbom=true"] : "";
 
 await $`docker buildx build --file ./ConsumerApi/Dockerfile --tag ghcr.io/nmshd/backbone-consumer-api:${tag} --platform ${platforms} ${push} .`;

--- a/.ci/fsc/buildContainerImage.js
+++ b/.ci/fsc/buildContainerImage.js
@@ -6,6 +6,6 @@ import { getRequiredEnvVar } from "../lib.js";
 const tag = getRequiredEnvVar("TAG");
 
 const platforms = process.env.PLATFORMS ?? "linux/amd64,linux/arm64";
-const push = process.env.PUSH === "1" ? "--push --provenance=true --sbom=true" : "";
+const push = process.env.PUSH === "1" ? ["--push", "--provenance=true", "--sbom=true"] : "";
 
 await $`docker buildx build --file ./Modules/Files/src/Files.Jobs.SanityCheck/Dockerfile --tag ghcr.io/nmshd/backbone-files-sanity-check:${tag} --platform ${platforms} ${push} .`;


### PR DESCRIPTION
# Readiness checklist

-   [ ] I added/updated unit tests.
-   [ ] I added/updated integration tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.
