### PR TITLE
Admin UI: Neither tier quotas nor tier quota definitions are not merged after attempting to delete tier quota definitions

### DIFF
--- a/Modules/Quotas/src/Quotas.Application/Infrastructure/Persistence/Repository/ITiersRepository.cs
+++ b/Modules/Quotas/src/Quotas.Application/Infrastructure/Persistence/Repository/ITiersRepository.cs
@@ -7,5 +7,6 @@ public interface ITiersRepository
     Task<Tier> Find(string id, CancellationToken cancellationToken, bool track = false);
     Task<TierQuotaDefinition> FindTierQuotaDefinition(string id, CancellationToken cancellationToken, bool track = false);
     Task RemoveById(TierId tierId);
+    Task RemoveTierQuotaDefinitionIfOrphaned(TierQuotaDefinitionId tierQuotaDefinitionId);
     Task Update(Tier tier, CancellationToken cancellationToken);
 }

--- a/Modules/Quotas/src/Quotas.Application/Tiers/Triggers/DeleteTierQuotaDefinitionsTrigger.cs
+++ b/Modules/Quotas/src/Quotas.Application/Tiers/Triggers/DeleteTierQuotaDefinitionsTrigger.cs
@@ -1,0 +1,14 @@
+﻿using Backbone.Modules.Quotas.Application.Infrastructure.Persistence.Repository;
+using Backbone.Modules.Quotas.Domain.Aggregates.Tiers;
+using EntityFrameworkCore.Triggered;
+
+namespace Backbone.Modules.Quotas.Application.Tiers.Triggers;
+
+public class DeleteTierQuotaDefinitionsTrigger(ITiersRepository tiersRepository) : IAfterSaveTrigger<TierQuotaDefinition>
+{
+    public async Task AfterSave(ITriggerContext<TierQuotaDefinition> context, CancellationToken cancellationToken)
+    {
+        if (context.ChangeType == ChangeType.Modified)
+            await tiersRepository.RemoveTierQuotaDefinitionIfOrphaned(context.Entity.Id);
+    }
+}

--- a/Modules/Quotas/src/Quotas.Domain/Quotas.Domain.csproj
+++ b/Modules/Quotas/src/Quotas.Domain/Quotas.Domain.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="CSharpFunctionalExtensions" Version="2.40.3" />
+    <PackageReference Include="EntityFrameworkCore.Triggered" Version="3.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Modules/Quotas/src/Quotas.Infrastructure/Persistence/Database/IServiceCollectionExtensions.cs
+++ b/Modules/Quotas/src/Quotas.Infrastructure/Persistence/Database/IServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Backbone.Modules.Quotas.Application.Infrastructure.Persistence.Repository;
 using Backbone.Modules.Quotas.Application.Metrics;
+using Backbone.Modules.Quotas.Application.Tiers.Triggers;
 using Backbone.Modules.Quotas.Domain.Metrics;
 using Backbone.Modules.Quotas.Infrastructure.Persistence.Repository;
 using Microsoft.EntityFrameworkCore;
@@ -51,6 +52,10 @@ public static class IServiceCollectionExtensions
                     default:
                         throw new Exception($"Unsupported database provider: {options.Provider}");
                 }
+
+                dbContextOptions.UseTriggers(triggerOptions => {
+                    triggerOptions.AddTrigger<DeleteTierQuotaDefinitionsTrigger>();
+                });
             });
         services.AddTransient<IIdentitiesRepository, IdentitiesRepository>();
         services.AddTransient<IMessagesRepository, MessagesRepository>();

--- a/Modules/Quotas/src/Quotas.Infrastructure/Persistence/Repository/TiersRepository.cs
+++ b/Modules/Quotas/src/Quotas.Infrastructure/Persistence/Repository/TiersRepository.cs
@@ -1,4 +1,6 @@
-﻿using Backbone.BuildingBlocks.Application.Extensions;
+﻿using System.Threading;
+using Backbone.BuildingBlocks.Application.Abstractions.Infrastructure.Persistence.Database;
+using Backbone.BuildingBlocks.Application.Extensions;
 using Backbone.Modules.Quotas.Application.Infrastructure.Persistence.Repository;
 using Backbone.Modules.Quotas.Domain.Aggregates.Tiers;
 using Backbone.Modules.Quotas.Infrastructure.Persistence.Database;
@@ -51,6 +53,21 @@ public class TiersRepository : ITiersRepository
     public async Task RemoveById(TierId tierId)
     {
         await _tiers.Where(t => t.Id == tierId).ExecuteDeleteAsync();
+    }
+
+    public async Task RemoveTierQuotaDefinitionIfOrphaned(TierQuotaDefinitionId tierQuotaDefinitionId)
+    {
+        //await _tierQuotaDefinitions.Where(t => t.Id == tierQuotaDefinitionId).ExecuteDeleteAsync();
+
+        //var allTierQuotaDefinitions = await _tierQuotaDefinitions.ToListAsync();
+        //var tierQuotaDefinitionsWithTierIdNull = allTierQuotaDefinitions.Where(t => _dbContext.Entry(t).Property("TierId").CurrentValue == null).ToList();
+        //var idsOfTierQuotasWithTierIdNull = tierQuotaDefinitionsWithTierIdNull.Select(t => t.Id).ToList();
+        //await _tierQuotaDefinitions.Where(t => idsOfTierQuotasWithTierIdNull.Contains(t.Id)).ExecuteDeleteAsync();
+
+        var tierQuotaDefinition = await _tierQuotaDefinitions.FirstWithId(tierQuotaDefinitionId, CancellationToken.None);
+
+        if (_dbContext.Entry(tierQuotaDefinition).Property("TierId").CurrentValue == null)
+            await _tierQuotaDefinitions.Where(t => t.Id == tierQuotaDefinitionId).ExecuteDeleteAsync();
     }
 
     public async Task Update(Tier tier, CancellationToken cancellationToken)


### PR DESCRIPTION
# Readiness checklist

-   [ ] I added/updated unit tests.
-   [ ] I added/updated integration tests.
-   [X] I ensured that the PR title is good enough for the changelog.
-   [X] I labeled the PR.

# Description
Prior to fixing it the attempt at deleting the tier quota definition in the Admin UI would imply orphan it, i.e. set its `TierId` column value to `null`, making it in effect "orphaned" (not connected to any `Tier` entity). Database operation trigger is introduced that is activated after updating tier quota definition and which deletes the said definition should it turn out to be orphaned.