### PR TITLE
fix: introduce dedicated lock object

### DIFF
--- a/Modules/Quotas/src/Quotas.Domain/Aggregates/Identities/Identity.cs
+++ b/Modules/Quotas/src/Quotas.Domain/Aggregates/Identities/Identity.cs
@@ -13,6 +13,8 @@ public class Identity
     private readonly List<IndividualQuota> _individualQuotas;
     private readonly List<MetricStatus> _metricStatuses;
 
+    private readonly object _latestExhaustionDateLock = new();
+
     // ReSharper disable once UnusedMember.Local
     private Identity()
     {
@@ -120,7 +122,7 @@ public class Identity
 
             var quotaExhaustion = quota.CalculateExhaustion(newUsage);
 
-            lock (latestExhaustionDate)
+            lock (_latestExhaustionDateLock)
             {
                 if (quotaExhaustion > latestExhaustionDate)
                     latestExhaustionDate = quotaExhaustion;


### PR DESCRIPTION
# Readiness checklist

-   [ ] I added/updated unit tests.
-   [ ] I added/updated integration tests.
-   [ ] I ensured that the PR title is good enough for the changelog.
-   [ ] I labeled the PR.

# Description

The lock shouldn't be a variable which will have another reference assigned to it within the critical area it is supposed to protect. Accessing the methods of the lock object or changing the values of its fields is allowed, but not changing the reference value of the lock itself.

That said, this is why this code in `BuildingBlocks.Infrastructure.Persistence.BlobStorage.AzureStorageAccount.AzureStorageAccountContainerClientFactory` for example yields no warnings:
```
        lock (_containerClients)
        {
            if (_containerClients.TryGetValue(containerName, out container))
                return container;

            var newContainer = CreateContainerClient(containerName);

            _containerClients.Add(containerName, newContainer);

            return newContainer;
        }
```