### PR TITLE
Consumer API: Internal server error when starting a sync run after starting an identity deletion process

### DIFF
--- a/Modules/Synchronization/src/Synchronization.Application/SyncRuns/DTOs/ExternalEventDTO.cs
+++ b/Modules/Synchronization/src/Synchronization.Application/SyncRuns/DTOs/ExternalEventDTO.cs
@@ -21,6 +21,8 @@ public class ExternalEventDTO : IHaveCustomMapping
             ExternalEventType.MessageReceived => "MessageReceived",
             ExternalEventType.RelationshipChangeCreated => "RelationshipChangeCreated",
             ExternalEventType.RelationshipChangeCompleted => "RelationshipChangeCompleted",
+            ExternalEventType.IdentityDeletionProcessStarted => "IdentityDeletionProcessStarted",
+            ExternalEventType.IdentityDeletionProcessStatusChanged => "IdentityDeletionProcessStatusChanged",
             _ => throw new ArgumentOutOfRangeException(nameof(externalEventType), externalEventType, null)
         });
         configuration.CreateMap<ExternalEvent, ExternalEventDTO>();


### PR DESCRIPTION
# Readiness checklist

-   [ ] I added/updated unit tests.
-   [ ] I added/updated integration tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.
