### PR TITLE
Consumer API: Remove last remains of RelationshipCreated DomainEvent

### DIFF
--- a/Modules/Synchronization/src/Synchronization.Application/SyncRuns/DTOs/ExternalEventDTO.cs
+++ b/Modules/Synchronization/src/Synchronization.Application/SyncRuns/DTOs/ExternalEventDTO.cs
@@ -19,7 +19,6 @@ public class ExternalEventDTO : IHaveCustomMapping
         {
             ExternalEventType.MessageDelivered => "MessageDelivered",
             ExternalEventType.MessageReceived => "MessageReceived",
-            ExternalEventType.RelationshipCreated => "RelationshipCreated",
             ExternalEventType.RelationshipStatusChanged => "RelationshipStatusChanged",
             ExternalEventType.IdentityDeletionProcessStarted => "IdentityDeletionProcessStarted",
             ExternalEventType.IdentityDeletionProcessStatusChanged => "IdentityDeletionProcessStatusChanged",

--- a/Modules/Synchronization/src/Synchronization.Domain/Entities/Sync/ExternalEvent.cs
+++ b/Modules/Synchronization/src/Synchronization.Domain/Entities/Sync/ExternalEvent.cs
@@ -58,10 +58,9 @@ public enum ExternalEventType
 {
     MessageReceived = 0,
     MessageDelivered = 1,
-    RelationshipCreated = 2,
-    RelationshipStatusChanged = 3,
-    IdentityDeletionProcessStarted = 4,
-    IdentityDeletionProcessStatusChanged = 5,
-    RelationshipTerminated = 6,
-    RelationshipReactivationRequested = 7
+    RelationshipStatusChanged = 2,
+    IdentityDeletionProcessStarted = 3,
+    IdentityDeletionProcessStatusChanged = 4,
+    RelationshipTerminated = 5,
+    RelationshipReactivationRequested = 6
 }


### PR DESCRIPTION

# Readiness checklist

-   [ ] I added/updated unit tests.
-   [ ] I added/updated integration tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.

# Descripiton

`RelationshipChanged` as a type is removed from `ExternalEvent` and subsequent external event type is removed from `ExternalEventDTO`.