### PR TITLE
Consumer API: Return updated Relationship after termination

### DIFF
--- a/Modules/Relationships/src/Relationships.Application/Relationships/Commands/TerminateRelationship/Handler.cs
+++ b/Modules/Relationships/src/Relationships.Application/Relationships/Commands/TerminateRelationship/Handler.cs
@@ -2,13 +2,14 @@
 using Backbone.BuildingBlocks.Application.Abstractions.Infrastructure.UserContext;
 using Backbone.DevelopmentKit.Identity.ValueObjects;
 using Backbone.Modules.Relationships.Application.Infrastructure.Persistence.Repository;
+using Backbone.Modules.Relationships.Application.Relationships.DTOs;
 using Backbone.Modules.Relationships.Domain.Aggregates.Relationships;
 using Backbone.Modules.Relationships.Domain.DomainEvents.Outgoing;
 using MediatR;
 
 namespace Backbone.Modules.Relationships.Application.Relationships.Commands.TerminateRelationship;
 
-public class Handler : IRequestHandler<TerminateRelationshipCommand, TerminateRelationshipResponse>
+public class Handler : IRequestHandler<TerminateRelationshipCommand, RelationshipDTO>
 {
     private readonly IRelationshipsRepository _relationshipsRepository;
     private readonly IEventBus _eventBus;
@@ -23,7 +24,7 @@ public class Handler : IRequestHandler<TerminateRelationshipCommand, TerminateRe
         _activeDevice = userContext.GetDeviceId();
     }
 
-    public async Task<TerminateRelationshipResponse> Handle(TerminateRelationshipCommand request, CancellationToken cancellationToken)
+    public async Task<RelationshipDTO> Handle(TerminateRelationshipCommand request, CancellationToken cancellationToken)
     {
         var relationshipId = RelationshipId.Parse(request.RelationshipId);
         var relationship = await _relationshipsRepository.FindRelationship(relationshipId, _activeIdentity, cancellationToken, track: true);
@@ -34,6 +35,6 @@ public class Handler : IRequestHandler<TerminateRelationshipCommand, TerminateRe
 
         _eventBus.Publish(new RelationshipStatusChangedDomainEvent(relationship));
 
-        return new TerminateRelationshipResponse(relationship);
+        return new RelationshipDTO(relationship);
     }
 }

--- a/Modules/Relationships/src/Relationships.Application/Relationships/Commands/TerminateRelationship/TerminateRelationshipCommand.cs
+++ b/Modules/Relationships/src/Relationships.Application/Relationships/Commands/TerminateRelationship/TerminateRelationshipCommand.cs
@@ -1,8 +1,8 @@
-﻿using Backbone.Modules.Relationships.Application.Relationships.Commands.CreateRelationship;
+﻿using Backbone.Modules.Relationships.Application.Relationships.DTOs;
 using MediatR;
 
 namespace Backbone.Modules.Relationships.Application.Relationships.Commands.TerminateRelationship;
-public class TerminateRelationshipCommand : IRequest<TerminateRelationshipResponse>
+public class TerminateRelationshipCommand : IRequest<RelationshipDTO>
 {
     public required string RelationshipId { get; set; }
 }

--- a/Modules/Relationships/src/Relationships.ConsumerApi/Controllers/RelationshipsController.cs
+++ b/Modules/Relationships/src/Relationships.ConsumerApi/Controllers/RelationshipsController.cs
@@ -101,13 +101,13 @@ public class RelationshipsController : ApiControllerBase
     }
 
     [HttpPut("{id}/Terminate")]
-    [ProducesResponseType(typeof(HttpResponseEnvelopeResult<TerminateRelationshipResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(HttpResponseEnvelopeResult<RelationshipDTO>), StatusCodes.Status200OK)]
     [ProducesError(StatusCodes.Status400BadRequest)]
     [ProducesError(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> TerminateRelationship([FromRoute] string id, CancellationToken cancellationToken)
     {
-        await _mediator.Send(new TerminateRelationshipCommand() { RelationshipId = id }, cancellationToken);
-        return NoContent();
+        var relationship = await _mediator.Send(new TerminateRelationshipCommand() { RelationshipId = id }, cancellationToken);
+        return Ok(relationship);
     }
 
     [HttpPut("{id}/Reactivate")]


### PR DESCRIPTION
# Readiness checklist

-   [ ] I added/updated unit tests.
-   [ ] I added/updated integration tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.

# Description
Return a `RelationshipDTO` after terminating a Relationship.