### PR TITLE
Consumer API: Requesting/completing relationship reactivations does not create external events

### DIFF
--- a/Modules/Synchronization/src/Synchronization.Application/DomainEvents/Incoming/RelationshipReactivationRequested/RelationshipReactivationRequestedDomainEventHandler.cs
+++ b/Modules/Synchronization/src/Synchronization.Application/DomainEvents/Incoming/RelationshipReactivationRequested/RelationshipReactivationRequestedDomainEventHandler.cs
@@ -8,7 +8,8 @@ using Backbone.Modules.Synchronization.Domain.Entities.Sync;
 using Microsoft.Extensions.Logging;
 
 namespace Backbone.Modules.Synchronization.Application.DomainEvents.Incoming.RelationshipReactivationRequested;
-public class RelationshipReactivationRequestedDomainEventHandler
+
+public class RelationshipReactivationRequestedDomainEventHandler : IDomainEventHandler<RelationshipReactivationRequestedDomainEvent>
 {
     private readonly ISynchronizationDbContext _dbContext;
     private readonly IEventBus _eventBus;

--- a/Modules/Synchronization/src/Synchronization.Application/Extensions/IEventBusExtensions.cs
+++ b/Modules/Synchronization/src/Synchronization.Application/Extensions/IEventBusExtensions.cs
@@ -2,10 +2,14 @@ using Backbone.BuildingBlocks.Application.Abstractions.Infrastructure.EventBus;
 using Backbone.Modules.Synchronization.Application.DomainEvents.Incoming.IdentityDeletionProcessStarted;
 using Backbone.Modules.Synchronization.Application.DomainEvents.Incoming.IdentityDeletionProcessStatusChanged;
 using Backbone.Modules.Synchronization.Application.DomainEvents.Incoming.MessageCreated;
+using Backbone.Modules.Synchronization.Application.DomainEvents.Incoming.RelationshipReactivationCompleted;
+using Backbone.Modules.Synchronization.Application.DomainEvents.Incoming.RelationshipReactivationRequested;
 using Backbone.Modules.Synchronization.Application.DomainEvents.Incoming.RelationshipStatusChanged;
 using Backbone.Modules.Synchronization.Domain.DomainEvents.Incoming.IdentityDeletionProcessStarted;
 using Backbone.Modules.Synchronization.Domain.DomainEvents.Incoming.IdentityDeletionProcessStatusChanged;
 using Backbone.Modules.Synchronization.Domain.DomainEvents.Incoming.MessageCreated;
+using Backbone.Modules.Synchronization.Domain.DomainEvents.Incoming.RelationshipReactivationCompleted;
+using Backbone.Modules.Synchronization.Domain.DomainEvents.Incoming.RelationshipReactivationRequested;
 using Backbone.Modules.Synchronization.Domain.DomainEvents.Incoming.RelationshipStatusChanged;
 
 namespace Backbone.Modules.Synchronization.Application.Extensions;
@@ -31,5 +35,7 @@ public static class IEventBusExtensions
     private static void SubscribeToRelationshipsEvents(IEventBus eventBus)
     {
         eventBus.Subscribe<RelationshipStatusChangedDomainEvent, RelationshipStatusChangedDomainEventHandler>();
+        eventBus.Subscribe<RelationshipReactivationRequestedDomainEvent, RelationshipReactivationRequestedDomainEventHandler>();
+        eventBus.Subscribe<RelationshipReactivationCompletedDomainEvent, RelationshipReactivationCompletedDomainEventHandler>();
     }
 }

--- a/Modules/Synchronization/src/Synchronization.Application/SyncRuns/DTOs/ExternalEventDTO.cs
+++ b/Modules/Synchronization/src/Synchronization.Application/SyncRuns/DTOs/ExternalEventDTO.cs
@@ -24,6 +24,7 @@ public class ExternalEventDTO : IHaveCustomMapping
             ExternalEventType.IdentityDeletionProcessStatusChanged => "IdentityDeletionProcessStatusChanged",
             ExternalEventType.RelationshipTerminated => "RelationshipTerminated",
             ExternalEventType.RelationshipReactivationRequested => "RelationshipReactivationRequested",
+            ExternalEventType.RelationshipReactivationCompleted => "RelationshipReactivationCompleted",
             ExternalEventType.RelationshipDecomposedByPeer => "RelationshipDecomposedByPeer",
             _ => throw new ArgumentOutOfRangeException(nameof(externalEventType), externalEventType, null)
         });


### PR DESCRIPTION
# Readiness checklist

-   [ ] I added/updated unit tests.
-   [ ] I added/updated integration tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.
