### PR TITLE
Consumer API: RelationshipReactivationCompleted external event is sent to wrong relationship participant

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -203,6 +203,8 @@ jobs:
       - publish-admin-ui
       - publish-consumer-api
       - publish-event-handler
+      - publish-database-migrator
+      - publish-identity-deletion-jobs
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/Modules/Relationships/src/Relationships.Application/Relationships/Commands/AcceptRelationshipReactivation/Handler.cs
+++ b/Modules/Relationships/src/Relationships.Application/Relationships/Commands/AcceptRelationshipReactivation/Handler.cs
@@ -7,6 +7,7 @@ using Backbone.Modules.Relationships.Domain.DomainEvents.Outgoing;
 using MediatR;
 
 namespace Backbone.Modules.Relationships.Application.Relationships.Commands.AcceptRelationshipReactivation;
+
 public class Handler : IRequestHandler<AcceptRelationshipReactivationCommand, AcceptRelationshipReactivationResponse>
 {
     private readonly IRelationshipsRepository _relationshipsRepository;
@@ -31,7 +32,7 @@ public class Handler : IRequestHandler<AcceptRelationshipReactivationCommand, Ac
 
         await _relationshipsRepository.Update(relationship);
 
-        _eventBus.Publish(new RelationshipReactivationCompletedDomainEvent(relationship, _activeIdentity));
+        _eventBus.Publish(new RelationshipReactivationCompletedDomainEvent(relationship, relationship.GetPeer(_activeIdentity)));
 
         return new AcceptRelationshipReactivationResponse(relationship);
     }

--- a/Modules/Relationships/src/Relationships.Application/Relationships/Commands/RejectRelationshipReactivation/Handler.cs
+++ b/Modules/Relationships/src/Relationships.Application/Relationships/Commands/RejectRelationshipReactivation/Handler.cs
@@ -1,5 +1,4 @@
-﻿using Backbone.BuildingBlocks.Application.Abstractions.Exceptions;
-using Backbone.BuildingBlocks.Application.Abstractions.Infrastructure.EventBus;
+﻿using Backbone.BuildingBlocks.Application.Abstractions.Infrastructure.EventBus;
 using Backbone.BuildingBlocks.Application.Abstractions.Infrastructure.UserContext;
 using Backbone.DevelopmentKit.Identity.ValueObjects;
 using Backbone.Modules.Relationships.Application.Infrastructure.Persistence.Repository;
@@ -8,6 +7,7 @@ using Backbone.Modules.Relationships.Domain.DomainEvents.Outgoing;
 using MediatR;
 
 namespace Backbone.Modules.Relationships.Application.Relationships.Commands.RejectRelationshipReactivation;
+
 public class Handler : IRequestHandler<RejectRelationshipReactivationCommand, RejectRelationshipReactivationResponse>
 {
     private readonly IRelationshipsRepository _relationshipsRepository;
@@ -33,7 +33,7 @@ public class Handler : IRequestHandler<RejectRelationshipReactivationCommand, Re
 
         await _relationshipsRepository.Update(relationship);
 
-        _eventBus.Publish(new RelationshipReactivationCompletedDomainEvent(relationship, _activeIdentity));
+        _eventBus.Publish(new RelationshipReactivationCompletedDomainEvent(relationship, relationship.GetPeer(_activeIdentity)));
 
         return new RejectRelationshipReactivationResponse(relationship);
     }

--- a/Modules/Relationships/src/Relationships.Application/Relationships/Commands/RelationshipReactivationRequest/RequestRelationshipReactivationCommand.cs
+++ b/Modules/Relationships/src/Relationships.Application/Relationships/Commands/RelationshipReactivationRequest/RequestRelationshipReactivationCommand.cs
@@ -1,9 +1,0 @@
-﻿using Backbone.BuildingBlocks.Application.Attributes;
-using MediatR;
-
-namespace Backbone.Modules.Relationships.Application.Relationships.Commands.RelationshipReactivationRequest;
-
-public class RequestRelationshipReactivationCommand : IRequest<RequestRelationshipReactivationResponse>
-{
-    public required string RelationshipId { get; set; }
-}

--- a/Modules/Relationships/src/Relationships.Application/Relationships/Commands/RequestRelationshipReactivation/Handler.cs
+++ b/Modules/Relationships/src/Relationships.Application/Relationships/Commands/RequestRelationshipReactivation/Handler.cs
@@ -6,7 +6,7 @@ using Backbone.Modules.Relationships.Domain.Aggregates.Relationships;
 using Backbone.Modules.Relationships.Domain.DomainEvents.Outgoing;
 using MediatR;
 
-namespace Backbone.Modules.Relationships.Application.Relationships.Commands.RelationshipReactivationRequest;
+namespace Backbone.Modules.Relationships.Application.Relationships.Commands.RequestRelationshipReactivation;
 
 public class Handler : IRequestHandler<RequestRelationshipReactivationCommand, RequestRelationshipReactivationResponse>
 {
@@ -22,6 +22,7 @@ public class Handler : IRequestHandler<RequestRelationshipReactivationCommand, R
         _activeIdentity = userContext.GetAddress();
         _activeDevice = userContext.GetDeviceId();
     }
+
     public async Task<RequestRelationshipReactivationResponse> Handle(RequestRelationshipReactivationCommand request, CancellationToken cancellationToken)
     {
         var relationshipId = RelationshipId.Parse(request.RelationshipId);
@@ -31,9 +32,7 @@ public class Handler : IRequestHandler<RequestRelationshipReactivationCommand, R
 
         await _relationshipsRepository.Update(relationship);
 
-        var peer = relationship.To == _activeIdentity ? relationship.From : relationship.To;
-
-        _eventBus.Publish(new RelationshipReactivationRequestedDomainEvent(relationship, _activeIdentity, peer));
+        _eventBus.Publish(new RelationshipReactivationRequestedDomainEvent(relationship, _activeIdentity, relationship.GetPeer(_activeIdentity)));
 
         return new RequestRelationshipReactivationResponse(relationship);
     }

--- a/Modules/Relationships/src/Relationships.Application/Relationships/Commands/RequestRelationshipReactivation/RequestRelationshipReactivationCommand.cs
+++ b/Modules/Relationships/src/Relationships.Application/Relationships/Commands/RequestRelationshipReactivation/RequestRelationshipReactivationCommand.cs
@@ -1,0 +1,8 @@
+﻿using MediatR;
+
+namespace Backbone.Modules.Relationships.Application.Relationships.Commands.RequestRelationshipReactivation;
+
+public class RequestRelationshipReactivationCommand : IRequest<RequestRelationshipReactivationResponse>
+{
+    public required string RelationshipId { get; set; }
+}

--- a/Modules/Relationships/src/Relationships.Application/Relationships/Commands/RequestRelationshipReactivation/RequestRelationshipReactivationResponse.cs
+++ b/Modules/Relationships/src/Relationships.Application/Relationships/Commands/RequestRelationshipReactivation/RequestRelationshipReactivationResponse.cs
@@ -1,7 +1,7 @@
 ﻿using Backbone.Modules.Relationships.Application.Relationships.DTOs;
 using Backbone.Modules.Relationships.Domain.Aggregates.Relationships;
 
-namespace Backbone.Modules.Relationships.Application.Relationships.Commands.RelationshipReactivationRequest;
+namespace Backbone.Modules.Relationships.Application.Relationships.Commands.RequestRelationshipReactivation;
 
 public class RequestRelationshipReactivationResponse : RelationshipMetadataDTO
 {

--- a/Modules/Relationships/src/Relationships.Application/Relationships/Commands/RevokeRelationshipReactivation/Handler.cs
+++ b/Modules/Relationships/src/Relationships.Application/Relationships/Commands/RevokeRelationshipReactivation/Handler.cs
@@ -7,6 +7,7 @@ using Backbone.Modules.Relationships.Domain.DomainEvents.Outgoing;
 using MediatR;
 
 namespace Backbone.Modules.Relationships.Application.Relationships.Commands.RevokeRelationshipReactivation;
+
 public class Handler : IRequestHandler<RevokeRelationshipReactivationCommand, RevokeRelationshipReactivationResponse>
 {
     private readonly IRelationshipsRepository _relationshipsRepository;
@@ -31,9 +32,7 @@ public class Handler : IRequestHandler<RevokeRelationshipReactivationCommand, Re
 
         await _relationshipsRepository.Update(relationship);
 
-        var peer = relationship.To == _activeIdentity ? relationship.From : relationship.To;
-
-        _eventBus.Publish(new RelationshipReactivationCompletedDomainEvent(relationship, peer));
+        _eventBus.Publish(new RelationshipReactivationCompletedDomainEvent(relationship, relationship.GetPeer(_activeIdentity)));
 
         return new RevokeRelationshipReactivationResponse(relationship);
     }

--- a/Modules/Relationships/src/Relationships.ConsumerApi/Controllers/RelationshipsController.cs
+++ b/Modules/Relationships/src/Relationships.ConsumerApi/Controllers/RelationshipsController.cs
@@ -10,7 +10,7 @@ using Backbone.Modules.Relationships.Application.Relationships.Commands.CreateRe
 using Backbone.Modules.Relationships.Application.Relationships.Commands.DecomposeRelationship;
 using Backbone.Modules.Relationships.Application.Relationships.Commands.RejectRelationship;
 using Backbone.Modules.Relationships.Application.Relationships.Commands.RejectRelationshipReactivation;
-using Backbone.Modules.Relationships.Application.Relationships.Commands.RelationshipReactivationRequest;
+using Backbone.Modules.Relationships.Application.Relationships.Commands.RequestRelationshipReactivation;
 using Backbone.Modules.Relationships.Application.Relationships.Commands.RevokeRelationship;
 using Backbone.Modules.Relationships.Application.Relationships.Commands.RevokeRelationshipReactivation;
 using Backbone.Modules.Relationships.Application.Relationships.Commands.TerminateRelationship;

--- a/Modules/Relationships/src/Relationships.Domain/Aggregates/Relationships/Relationship.cs
+++ b/Modules/Relationships/src/Relationships.Domain/Aggregates/Relationships/Relationship.cs
@@ -62,6 +62,11 @@ public class Relationship
     public bool FromHasDecomposed { get; private set; }
     public bool ToHasDecomposed { get; private set; }
 
+    public IdentityAddress GetPeer(IdentityAddress activeIdentity)
+    {
+        return From == activeIdentity ? To : From;
+    }
+
     private static void EnsureTargetIsNotSelf(RelationshipTemplate relationshipTemplate, IdentityAddress activeIdentity)
     {
         if (activeIdentity == relationshipTemplate.CreatedBy)

--- a/Modules/Relationships/src/Relationships.Domain/DomainEvents/Outgoing/RelationshipStatusChangedDomainEvent.cs
+++ b/Modules/Relationships/src/Relationships.Domain/DomainEvents/Outgoing/RelationshipStatusChangedDomainEvent.cs
@@ -6,12 +6,13 @@ namespace Backbone.Modules.Relationships.Domain.DomainEvents.Outgoing;
 
 public class RelationshipStatusChangedDomainEvent : DomainEvent
 {
-    public RelationshipStatusChangedDomainEvent(Relationship relationship) : base($"{relationship.Id}/StatusChanged/{relationship.AuditLog.OrderBy(a => a.CreatedAt).Last().CreatedAt.ToUniversalString()}")
+    public RelationshipStatusChangedDomainEvent(Relationship relationship) : base(
+        $"{relationship.Id}/StatusChanged/{relationship.AuditLog.OrderBy(a => a.CreatedAt).Last().CreatedAt.ToUniversalString()}")
     {
         RelationshipId = relationship.Id;
         Status = relationship.Status.ToString();
         Initiator = relationship.LastModifiedBy;
-        Peer = relationship.LastModifiedBy == relationship.From ? relationship.To : relationship.From;
+        Peer = relationship.GetPeer(relationship.LastModifiedBy);
     }
 
     public string RelationshipId { get; set; }

--- a/Modules/Relationships/test/Relationships.Application.Tests/Tests/Relationships/Commands/AcceptRelationshipReactivation/HandlerTests.cs
+++ b/Modules/Relationships/test/Relationships.Application.Tests/Tests/Relationships/Commands/AcceptRelationshipReactivation/HandlerTests.cs
@@ -11,6 +11,7 @@ using FluentAssertions;
 using Xunit;
 
 namespace Backbone.Modules.Relationships.Application.Tests.Tests.Relationships.Commands.AcceptRelationshipReactivation;
+
 public class HandlerTests
 {
     [Fact]
@@ -108,7 +109,7 @@ public class HandlerTests
         A.CallTo(
                 () => mockEventBus.Publish(A<RelationshipReactivationCompletedDomainEvent>.That.Matches(e =>
                     e.RelationshipId == relationship.Id &&
-                    e.Peer == activeIdentity)
+                    e.Peer == identityTo)
                 ))
             .MustHaveHappenedOnceExactly();
     }

--- a/Modules/Relationships/test/Relationships.Application.Tests/Tests/Relationships/Commands/RejectRelationshipReactivation/HandlerTests.cs
+++ b/Modules/Relationships/test/Relationships.Application.Tests/Tests/Relationships/Commands/RejectRelationshipReactivation/HandlerTests.cs
@@ -11,6 +11,7 @@ using FluentAssertions;
 using Xunit;
 
 namespace Backbone.Modules.Relationships.Application.Tests.Tests.Relationships.Commands.RejectRelationshipReactivation;
+
 public class HandlerTests
 {
     [Fact]
@@ -76,7 +77,7 @@ public class HandlerTests
         A.CallTo(
                 () => mockEventBus.Publish(A<RelationshipReactivationCompletedDomainEvent>.That.Matches(e =>
                     e.RelationshipId == relationship.Id &&
-                    e.Peer == activeIdentity)
+                    e.Peer == identityTo)
                 ))
             .MustHaveHappenedOnceExactly();
     }

--- a/Modules/Relationships/test/Relationships.Application.Tests/Tests/Relationships/Commands/RelationshipReactivationRequest/HandlerTests.cs
+++ b/Modules/Relationships/test/Relationships.Application.Tests/Tests/Relationships/Commands/RelationshipReactivationRequest/HandlerTests.cs
@@ -1,7 +1,7 @@
 ﻿using Backbone.BuildingBlocks.Application.Abstractions.Infrastructure.EventBus;
 using Backbone.BuildingBlocks.Application.Abstractions.Infrastructure.UserContext;
 using Backbone.Modules.Relationships.Application.Infrastructure.Persistence.Repository;
-using Backbone.Modules.Relationships.Application.Relationships.Commands.RelationshipReactivationRequest;
+using Backbone.Modules.Relationships.Application.Relationships.Commands.RequestRelationshipReactivation;
 using Backbone.Modules.Relationships.Application.Tests.TestHelpers;
 using Backbone.Modules.Relationships.Domain.Aggregates.Relationships;
 using Backbone.UnitTestTools.Data;
@@ -10,6 +10,7 @@ using FluentAssertions;
 using Xunit;
 
 namespace Backbone.Modules.Relationships.Application.Tests.Tests.Relationships.Commands.RelationshipReactivationRequest;
+
 public class HandlerTests
 {
     [Fact]


### PR DESCRIPTION
# Readiness checklist

-   [x] I added/updated unit tests.
-   [ ] I added/updated integration tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.
