### PR TITLE
Updating entities can cause errors

### DIFF
--- a/Backbone.Tests.ArchUnit/DomainDrivenDesign.cs
+++ b/Backbone.Tests.ArchUnit/DomainDrivenDesign.cs
@@ -1,0 +1,28 @@
+using ArchUnitNET.Domain.Extensions;
+using ArchUnitNET.Fluent.Conditions;
+using ArchUnitNET.xUnit;
+using Backbone.BuildingBlocks.Domain;
+using static ArchUnitNET.Fluent.ArchRuleDefinition;
+
+namespace Backbone.Backbone.Tests.ArchUnit;
+
+public class DomainDrivenDesign
+{
+    [Fact]
+    public void EntitiesShouldHaveEmptyDefaultConstructors()
+    {
+        Types()
+            .That().AreAssignableTo(typeof(Entity))
+            .Should().FollowCustomCondition((type) =>
+            {
+                var constructors = type.GetConstructors();
+
+                if (constructors.All(c => c.Parameters.Count() != 0))
+                    return new ConditionResult(type, false, "Entity should have a parameterless constructor");
+
+                return new ConditionResult(type, true);
+            }, "")
+            .Because("otherwise the real constructor would be called by EF Core, which would add a domain event to the collection")
+            .Check(Backbone.ARCHITECTURE);
+    }
+}

--- a/Modules/Devices/src/Devices.Domain/Entities/Identities/Identity.cs
+++ b/Modules/Devices/src/Devices.Domain/Entities/Identities/Identity.cs
@@ -15,6 +15,17 @@ public class Identity : Entity
     private readonly List<IdentityDeletionProcess> _deletionProcesses;
     private TierId? _tierId;
 
+    // ReSharper disable once UnusedMember.Local
+    private Identity()
+    {
+        // This constructor is for EF Core only; initializing the properties with null is therefore not a problem
+        ClientId = null!;
+        Address = null!;
+        PublicKey = null!;
+        Devices = null!;
+        _deletionProcesses = null!;
+    }
+
     public Identity(string clientId, IdentityAddress address, byte[] publicKey, TierId tierId, byte identityVersion)
     {
         ClientId = clientId;

--- a/Modules/Devices/src/Devices.Domain/Entities/OAuthClient.cs
+++ b/Modules/Devices/src/Devices.Domain/Entities/OAuthClient.cs
@@ -5,6 +5,15 @@ namespace Backbone.Modules.Devices.Domain.Entities;
 
 public class OAuthClient : Entity
 {
+    // ReSharper disable once UnusedMember.Local
+    private OAuthClient()
+    {
+        // This constructor is for EF Core only; initializing the properties with null is therefore not a problem
+        ClientId = null!;
+        DisplayName = null!;
+        DefaultTier = null!;
+    }
+
     public OAuthClient(string clientId, string displayName, TierId defaultTier, DateTime createdAt, int? maxIdentities)
     {
         ClientId = clientId;

--- a/Modules/Messages/src/Messages.Domain/Entities/Attachment.cs
+++ b/Modules/Messages/src/Messages.Domain/Entities/Attachment.cs
@@ -5,6 +5,14 @@ namespace Backbone.Modules.Messages.Domain.Entities;
 
 public class Attachment : Entity
 {
+    // ReSharper disable once UnusedMember.Local
+    private Attachment()
+    {
+        // This constructor is for EF Core only; initializing the properties with null is therefore not a problem
+        Id = null!;
+        MessageId = null!;
+    }
+
     public Attachment(FileId id)
     {
         Id = id;

--- a/Modules/Relationships/src/Relationships.Domain/Entities/RelationshipTemplateAllocation.cs
+++ b/Modules/Relationships/src/Relationships.Domain/Entities/RelationshipTemplateAllocation.cs
@@ -8,6 +8,15 @@ namespace Backbone.Modules.Relationships.Domain.Entities;
 
 public class RelationshipTemplateAllocation : Entity
 {
+    // ReSharper disable once UnusedMember.Local
+    private RelationshipTemplateAllocation()
+    {
+        // This constructor is for EF Core only; initializing the properties with null is therefore not a problem
+        RelationshipTemplateId = null!;
+        AllocatedBy = null!;
+        AllocatedByDevice = null!;
+    }
+
     public RelationshipTemplateAllocation(RelationshipTemplateId relationshipTemplateId, IdentityAddress allocatedBy, DeviceId allocatedByDevice)
     {
         RelationshipTemplateId = relationshipTemplateId;


### PR DESCRIPTION
# Readiness checklist

-   [ ] I added/updated unit tests.
-   [ ] I added/updated integration tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.

The problem was that when EF Core deserializes an entity, it used the "real" constructor. In case of an identity, this caused an IdentityCreatedDomainEvent to be created on an update, even though it isn't a new identity.
The Quotas module, which handles this domain event and creates a copy of the identity in their own schema, then runs into an error because an identity with that address already exists.

I fixed this by adding empty default constructors for all classes that inherit from Entity. This empty default constructor is prioritized by EF Core.