### PR TITLE
[AdminUI] Date filter text field acquires focus on interaction

### DIFF
--- a/AdminUi/apps/admin_ui/lib/core/widgets/filters/date_filter.dart
+++ b/AdminUi/apps/admin_ui/lib/core/widgets/filters/date_filter.dart
@@ -58,6 +58,7 @@ class _DateFilterState extends State<DateFilter> {
               child: TextField(
                 onTap: _selectNewDate,
                 readOnly: true,
+                canRequestFocus: false,
                 controller: _controller,
                 decoration: InputDecoration(
                   border: const OutlineInputBorder(),


### PR DESCRIPTION
# Readiness checklist

-   [ ] I added/updated unit tests.
-   [ ] I added/updated integration tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.

--- 

This TextField is not a typical one and should not get focus on press. Instead the label will only move to the top when the field is filled.
