### PR TITLE
Consumer API: Block new relationship when old one is in status deletion proposed

### DIFF
--- a/Modules/Relationships/src/Relationships.Domain/Aggregates/Relationships/Relationship.CreateTests.cs
+++ b/Modules/Relationships/src/Relationships.Domain/Aggregates/Relationships/Relationship.CreateTests.cs
@@ -98,6 +98,26 @@ public class RelationshipCreateTests : AbstractTestsBase
         acting.Should().Throw<DomainException>().WithError("error.platform.validation.relationshipRequest.relationshipToTargetAlreadyExists");
     }
 
+    [Theory]
+    [InlineData(RelationshipStatus.Pending)]
+    [InlineData(RelationshipStatus.Active)]
+    [InlineData(RelationshipStatus.Terminated)]
+    [InlineData(RelationshipStatus.DeletionProposed)]
+    public void There_can_only_be_one_active_relationship_between_two_identities2(RelationshipStatus relationshipStatus)
+    {
+        // Arrange
+        var existingRelationships = new List<Relationship>
+        {
+            CreateRelationshipInStatus(relationshipStatus)
+        };
+
+        // Act
+        var acting = () => new Relationship(RELATIONSHIP_TEMPLATE_OF_1, IDENTITY_2, DEVICE_2, null, existingRelationships);
+
+        // Assert
+        acting.Should().Throw<DomainException>().WithError("error.platform.validation.relationshipRequest.relationshipToTargetAlreadyExists");
+    }
+
     [Fact]
     public void Creating_a_new_relationship_is_possible_if_existing_ones_are_rejected_or_revoked()
     {
@@ -129,21 +149,5 @@ public class RelationshipCreateTests : AbstractTestsBase
 
         // Assert
         acting.Should().Throw<DomainException>().WithError("error.platform.validation.relationshipRequest.relationshipToTargetAlreadyExists");
-    }
-
-    [Fact]
-    public void A_new_relationship_can_be_created_after_decomposing_the_old_one()
-    {
-        // Arrange
-        var existingRelationships = new List<Relationship>
-        {
-            CreateDecomposedRelationship(IDENTITY_1, IDENTITY_2)
-        };
-
-        // Act
-        var newRelationship = new Relationship(RELATIONSHIP_TEMPLATE_OF_1, IDENTITY_2, DEVICE_2, [], existingRelationships);
-
-        // Assert
-        newRelationship.Status.Should().Be(RelationshipStatus.Pending);
     }
 }

--- a/Modules/Relationships/src/Relationships.Domain/Aggregates/Relationships/Relationship.cs
+++ b/Modules/Relationships/src/Relationships.Domain/Aggregates/Relationships/Relationship.cs
@@ -78,7 +78,7 @@ public class Relationship : Entity
 
     private static void EnsureNoOtherRelationshipToPeerExists(IdentityAddress target, IEnumerable<Relationship> existingRelationshipsToPeer)
     {
-        if (existingRelationshipsToPeer.Any(r => r.Status is RelationshipStatus.Active or RelationshipStatus.Pending or RelationshipStatus.Terminated))
+        if (existingRelationshipsToPeer.Any(r => r.Status is RelationshipStatus.Active or RelationshipStatus.Pending or RelationshipStatus.Terminated or RelationshipStatus.DeletionProposed))
             throw new DomainException(DomainErrors.RelationshipToTargetAlreadyExists(target));
     }
 

--- a/Modules/Relationships/src/Relationships.Domain/TestHelpers/TestData.cs
+++ b/Modules/Relationships/src/Relationships.Domain/TestHelpers/TestData.cs
@@ -25,6 +25,18 @@ public static class TestData
         return relationship;
     }
 
+    public static Relationship CreateRelationshipInStatus(RelationshipStatus status, IdentityAddress? from = null, IdentityAddress? to = null)
+    {
+        return status switch
+        {
+            RelationshipStatus.Pending => CreatePendingRelationship(from, to),
+            RelationshipStatus.Active => CreateActiveRelationship(from, to),
+            RelationshipStatus.Terminated => CreateTerminatedRelationship(from, to),
+            RelationshipStatus.DeletionProposed => CreateRelationshipWithProposedDeletion(from, to),
+            _ => throw new NotSupportedException($"This method currently does not support relationship status {status}.")
+        };
+    }
+
     public static Relationship CreateActiveRelationship(IdentityAddress? from = null, IdentityAddress? to = null)
     {
         to ??= IDENTITY_2;
@@ -54,7 +66,15 @@ public static class TestData
     public static Relationship CreateTerminatedRelationship(IdentityAddress? from = null, IdentityAddress? to = null)
     {
         var relationship = CreateActiveRelationship(from, to);
-        relationship.Terminate(IDENTITY_1, DEVICE_1);
+        relationship.Terminate(relationship.From, DEVICE_1);
+        relationship.ClearDomainEvents();
+        return relationship;
+    }
+
+    public static Relationship CreateRelationshipWithProposedDeletion(IdentityAddress? from = null, IdentityAddress? to = null)
+    {
+        var relationship = CreateTerminatedRelationship(from, to);
+        relationship.Decompose(relationship.From, DEVICE_1);
         relationship.ClearDomainEvents();
         return relationship;
     }


### PR DESCRIPTION
# Readiness checklist

-   [x] I added/updated unit tests.
-   [ ] I added/updated integration tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.
