### PR TITLE
Admin UI: allow other entrypoints to the Application than `/splash`

### DIFF
--- a/Applications/AdminUi/apps/admin_ui/lib/main.dart
+++ b/Applications/AdminUi/apps/admin_ui/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:admin_api_sdk/admin_api_sdk.dart';
 import 'package:data_table_2/data_table_2.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -30,17 +31,25 @@ final _shellNavigatorKey = GlobalKey<NavigatorState>();
 final _router = GoRouter(
   initialLocation: '/splash',
   navigatorKey: _rootNavigatorKey,
+  redirect: (context, state) {
+    if (GetIt.I.isRegistered<AdminApiClient>()) return null;
+
+    final fullPath = state.fullPath;
+    if (fullPath == null || fullPath.startsWith('/splash') || fullPath.startsWith('/login')) return null;
+
+    return '/splash?loc=${Uri.encodeComponent(state.fullPath!)}';
+  },
   routes: [
     GoRoute(path: '/index.html', redirect: (_, __) => '/splash'),
     GoRoute(
       parentNavigatorKey: _rootNavigatorKey,
       path: '/splash',
-      builder: (context, state) => const SplashScreen(),
+      builder: (context, state) => SplashScreen(redirect: state.uri.queryParameters['loc']),
     ),
     GoRoute(
       parentNavigatorKey: _rootNavigatorKey,
       path: '/login',
-      builder: (context, state) => const LoginScreen(),
+      builder: (context, state) => LoginScreen(redirect: state.uri.queryParameters['loc']),
     ),
     ShellRoute(
       navigatorKey: _shellNavigatorKey,
@@ -102,10 +111,7 @@ final _router = GoRouter(
           ],
         ),
       ],
-      builder: (context, state, child) => HomeScreen(
-        location: state.fullPath!,
-        child: child,
-      ),
+      builder: (context, state, child) => HomeScreen(location: state.fullPath!, child: child),
     ),
   ],
 );

--- a/Applications/AdminUi/apps/admin_ui/lib/main.dart
+++ b/Applications/AdminUi/apps/admin_ui/lib/main.dart
@@ -29,7 +29,7 @@ final _rootNavigatorKey = GlobalKey<NavigatorState>();
 final _shellNavigatorKey = GlobalKey<NavigatorState>();
 
 final _router = GoRouter(
-  initialLocation: '/splash',
+  initialLocation: '/identities/did:e:pilot.enmeshed.eu:dids:025482f25d134745abdf2b',
   navigatorKey: _rootNavigatorKey,
   redirect: (context, state) {
     if (GetIt.I.isRegistered<AdminApiClient>()) return null;
@@ -37,7 +37,7 @@ final _router = GoRouter(
     final fullPath = state.fullPath;
     if (fullPath == null || fullPath.startsWith('/splash') || fullPath.startsWith('/login')) return null;
 
-    return '/splash?loc=${Uri.encodeComponent(state.fullPath!)}';
+    return '/splash?loc=${Uri.encodeComponent(state.matchedLocation)}';
   },
   routes: [
     GoRoute(path: '/index.html', redirect: (_, __) => '/splash'),

--- a/Applications/AdminUi/apps/admin_ui/lib/main.dart
+++ b/Applications/AdminUi/apps/admin_ui/lib/main.dart
@@ -29,31 +29,24 @@ final _rootNavigatorKey = GlobalKey<NavigatorState>();
 final _shellNavigatorKey = GlobalKey<NavigatorState>();
 
 final _router = GoRouter(
-  initialLocation: '/identities/did:e:pilot.enmeshed.eu:dids:025482f25d134745abdf2b',
+  initialLocation: '/splash',
   navigatorKey: _rootNavigatorKey,
-  redirect: (context, state) {
-    if (GetIt.I.isRegistered<AdminApiClient>()) return null;
-
-    final fullPath = state.fullPath;
-    if (fullPath == null || fullPath.startsWith('/splash') || fullPath.startsWith('/login')) return null;
-
-    return '/splash?loc=${Uri.encodeComponent(state.matchedLocation)}';
-  },
   routes: [
     GoRoute(path: '/index.html', redirect: (_, __) => '/splash'),
     GoRoute(
       parentNavigatorKey: _rootNavigatorKey,
       path: '/splash',
-      builder: (context, state) => SplashScreen(redirect: state.uri.queryParameters['loc']),
+      builder: (context, state) => SplashScreen(redirect: state.uri.queryParameters['redirect']),
     ),
     GoRoute(
       parentNavigatorKey: _rootNavigatorKey,
       path: '/login',
-      builder: (context, state) => LoginScreen(redirect: state.uri.queryParameters['loc']),
+      builder: (context, state) => LoginScreen(redirect: state.uri.queryParameters['redirect']),
     ),
     ShellRoute(
       navigatorKey: _shellNavigatorKey,
       parentNavigatorKey: _rootNavigatorKey,
+      redirect: (context, state) => GetIt.I.isRegistered<AdminApiClient>() ? null : '/splash?redirect=${Uri.encodeComponent(state.matchedLocation)}',
       routes: [
         GoRoute(
           parentNavigatorKey: _shellNavigatorKey,

--- a/Applications/AdminUi/apps/admin_ui/lib/screens/login_screen.dart
+++ b/Applications/AdminUi/apps/admin_ui/lib/screens/login_screen.dart
@@ -7,7 +7,9 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '/core/core.dart';
 
 class LoginScreen extends StatefulWidget {
-  const LoginScreen({super.key});
+  final String? redirect;
+
+  const LoginScreen({required this.redirect, super.key});
 
   @override
   State<LoginScreen> createState() => _LoginScreenState();
@@ -106,6 +108,6 @@ class _LoginScreenState extends State<LoginScreen> {
 
     await GetIt.I.unregisterIfRegistered<AdminApiClient>();
     GetIt.I.registerSingleton(await AdminApiClient.create(baseUrl: baseUrl, apiKey: apiKey));
-    if (mounted) context.go('/identities');
+    if (mounted) context.go(widget.redirect != null ? Uri.decodeComponent(widget.redirect!) : '/identities');
   }
 }

--- a/Applications/AdminUi/apps/admin_ui/lib/screens/splash_screen.dart
+++ b/Applications/AdminUi/apps/admin_ui/lib/screens/splash_screen.dart
@@ -9,7 +9,9 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '/core/core.dart';
 
 class SplashScreen extends StatefulWidget {
-  const SplashScreen({super.key});
+  final String? redirect;
+
+  const SplashScreen({required this.redirect, super.key});
 
   @override
   State<SplashScreen> createState() => _SplashScreenState();
@@ -44,7 +46,11 @@ class _SplashScreenState extends State<SplashScreen> {
     final sp = await SharedPreferences.getInstance();
 
     if (!sp.containsKey('api_key')) {
-      if (mounted) context.go('/login');
+      if (mounted && widget.redirect != null) {
+        context.go('/login?loc=${widget.redirect!}');
+      } else if (mounted) {
+        context.go('/login');
+      }
 
       return;
     }
@@ -55,12 +61,17 @@ class _SplashScreenState extends State<SplashScreen> {
     final isValid = await AdminApiClient.validateApiKey(baseUrl: baseUrl, apiKey: apiKey);
     if (!isValid) {
       await sp.remove('api_key');
-      if (mounted) context.go('/login');
+
+      if (mounted && widget.redirect != null) {
+        context.go('/login?loc=${widget.redirect!}');
+      } else if (mounted) {
+        context.go('/login');
+      }
 
       return;
     }
 
     GetIt.I.registerSingleton(await AdminApiClient.create(baseUrl: baseUrl, apiKey: apiKey));
-    if (mounted) context.go('/identities');
+    if (mounted) context.go(widget.redirect != null ? Uri.decodeComponent(widget.redirect!) : '/identities');
   }
 }

--- a/Applications/AdminUi/apps/admin_ui/lib/screens/splash_screen.dart
+++ b/Applications/AdminUi/apps/admin_ui/lib/screens/splash_screen.dart
@@ -22,7 +22,7 @@ class _SplashScreenState extends State<SplashScreen> {
   void initState() {
     super.initState();
 
-    route();
+    _route();
   }
 
   @override
@@ -41,37 +41,27 @@ class _SplashScreenState extends State<SplashScreen> {
     );
   }
 
-  Future<void> route() async {
+  Future<void> _route() async {
     await GetIt.I.allReady();
     final sp = await SharedPreferences.getInstance();
 
-    if (!sp.containsKey('api_key')) {
-      if (mounted && widget.redirect != null) {
-        context.go('/login?redirect=${widget.redirect!}');
-      } else if (mounted) {
-        context.go('/login');
-      }
-
-      return;
-    }
+    if (!sp.containsKey('api_key')) return _navigate('/login');
 
     final apiKey = sp.getString('api_key')!;
     const baseUrl = kIsWeb ? '' : String.fromEnvironment('base_url');
 
     final isValid = await AdminApiClient.validateApiKey(baseUrl: baseUrl, apiKey: apiKey);
-    if (!isValid) {
-      await sp.remove('api_key');
-
-      if (mounted && widget.redirect != null) {
-        context.go('/login?redirect=${widget.redirect!}');
-      } else if (mounted) {
-        context.go('/login');
-      }
-
-      return;
-    }
+    if (!isValid) return _navigate('/login');
 
     GetIt.I.registerSingleton(await AdminApiClient.create(baseUrl: baseUrl, apiKey: apiKey));
-    if (mounted) context.go(widget.redirect != null ? Uri.decodeComponent(widget.redirect!) : '/identities');
+    return _navigate('/identities');
+  }
+
+  void _navigate(String defaultRoute) {
+    if (!mounted) return;
+
+    if (widget.redirect != null) return context.go(Uri.decodeComponent(widget.redirect!));
+
+    context.go(defaultRoute);
   }
 }

--- a/Applications/AdminUi/apps/admin_ui/lib/screens/splash_screen.dart
+++ b/Applications/AdminUi/apps/admin_ui/lib/screens/splash_screen.dart
@@ -47,7 +47,7 @@ class _SplashScreenState extends State<SplashScreen> {
 
     if (!sp.containsKey('api_key')) {
       if (mounted && widget.redirect != null) {
-        context.go('/login?loc=${widget.redirect!}');
+        context.go('/login?redirect=${widget.redirect!}');
       } else if (mounted) {
         context.go('/login');
       }
@@ -63,7 +63,7 @@ class _SplashScreenState extends State<SplashScreen> {
       await sp.remove('api_key');
 
       if (mounted && widget.redirect != null) {
-        context.go('/login?loc=${widget.redirect!}');
+        context.go('/login?redirect=${widget.redirect!}');
       } else if (mounted) {
         context.go('/login');
       }

--- a/Applications/AdminUi/apps/admin_ui/macos/Runner/AppDelegate.swift
+++ b/Applications/AdminUi/apps/admin_ui/macos/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import Cocoa
 import FlutterMacOS
 
-@NSApplicationMain
+@main
 class AppDelegate: FlutterAppDelegate {
   override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
     return true

--- a/Applications/AdminUi/apps/admin_ui/pubspec.lock
+++ b/Applications/AdminUi/apps/admin_ui/pubspec.lock
@@ -540,10 +540,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.4"
+    version: "14.2.5"
   watch_it:
     dependency: "direct main"
     description:


### PR DESCRIPTION
# Readiness checklist

-   [ ] I added/updated unit tests.
-   [ ] I added/updated integration tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.

# Description

When using the AdminUi in the browser we can directly go to `/identities/:id` which previously crashed the application. This should fix this behavior.