### PR TITLE
CanCreate returns true even though peer is in status ToBeDeleted

### DIFF
--- a/Applications/ConsumerApi/test/ConsumerApi.Tests.Integration/Features/Relationships/CanCreate/GET.feature
+++ b/Applications/ConsumerApi/test/ConsumerApi.Tests.Integration/Features/Relationships/CanCreate/GET.feature
@@ -36,3 +36,10 @@ Feature: GET /Relationships/CanCreate
         When i1 sends a GET request to the /Relationships/CanCreate?peer={id} endpoint with id=i2.id
         Then the response status code is 200 (OK)
         And a Relationship can be established
+
+    Scenario: Cannot create Relationship if peer is to be deleted
+        Given Identities i1 and i2
+        And i2 is in status "ToBeDeleted"
+        When i1 sends a GET request to the /Relationships/CanCreate?peer={id} endpoint with id=i2.id
+        Then the response status code is 200 (OK)
+        And a Relationship can not be established

--- a/Modules/Relationships/src/Relationships.ConsumerApi/Controllers/RelationshipsController.cs
+++ b/Modules/Relationships/src/Relationships.ConsumerApi/Controllers/RelationshipsController.cs
@@ -198,9 +198,14 @@ public class RelationshipsController : ApiControllerBase
     [HttpGet("CanCreate")]
     [ProducesResponseType(typeof(HttpResponseEnvelopeResult<CanEstablishRelationshipResponse>), StatusCodes.Status200OK)]
     [ProducesError(StatusCodes.Status400BadRequest)]
-    public async Task<IActionResult> CanEstablishRelationship([FromQuery] string peer, CancellationToken cancellationToken)
+    public async Task<IActionResult> CanEstablishRelationship([FromQuery(Name = "peer")] string peerAddress, CancellationToken cancellationToken)
     {
-        var response = await _mediator.Send(new CanEstablishRelationshipQuery { PeerAddress = peer }, cancellationToken);
+        var peerIdentity = await _mediator.Send(new GetIdentityQuery(peerAddress), cancellationToken);
+
+        var response = peerIdentity.Status is IdentityStatus.ToBeDeleted
+            ? new CanEstablishRelationshipResponse { CanCreate = false }
+            : await _mediator.Send(new CanEstablishRelationshipQuery { PeerAddress = peerAddress }, cancellationToken);
+
         return Ok(response);
     }
 


### PR DESCRIPTION
# Readiness checklist

-   [ ] I added/updated unit tests.
-   [x] I added/updated integration tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.
