### PR TITLE
Error message for `error.platform.validation.message.relationshipToRecipientNotActive` contains wrong address

### DIFF
--- a/Modules/Messages/src/Messages.Application/Messages/Commands/SendMessage/Handler.cs
+++ b/Modules/Messages/src/Messages.Application/Messages/Commands/SendMessage/Handler.cs
@@ -68,6 +68,7 @@ public class Handler : IRequestHandler<SendMessageCommand, SendMessageResponse>
             var numberOfUnreceivedMessagesFromActiveIdentity = await _messagesRepository.CountUnreceivedMessagesFromSenderToRecipient(sender, recipientDto.Address, cancellationToken);
 
             relationshipBetweenSenderAndRecipient.EnsureSendingMessagesIsAllowed(
+                _userContext.GetAddress(),
                 numberOfUnreceivedMessagesFromActiveIdentity,
                 _options.MaxNumberOfUnreceivedMessagesFromOneSender);
 

--- a/Modules/Messages/src/Messages.Domain/DomainErrors.cs
+++ b/Modules/Messages/src/Messages.Domain/DomainErrors.cs
@@ -10,7 +10,7 @@ public static class DomainErrors
 
         return new DomainError(
             "error.platform.validation.message.relationshipToRecipientNotActive",
-            $"Cannot send message to {recipientText} because the relationship to it is not active. In order to be able to send messages again, you have to reactivate the relationship.");
+            $"Cannot send message to {recipientText} because the relationship to it is not active. If it's terminated, you'll need to reactivate it to be able to send messages again.");
     }
 
     public static DomainError MaxNumberOfUnreceivedMessagesReached(string recipient = "")

--- a/Modules/Messages/src/Messages.Domain/Entities/Relationship.cs
+++ b/Modules/Messages/src/Messages.Domain/Entities/Relationship.cs
@@ -35,10 +35,10 @@ public class Relationship : Entity
 
     public RelationshipStatus Status { get; }
 
-    public void EnsureSendingMessagesIsAllowed(int numberOfUnreceivedMessagesFromActiveIdentity, int maxNumberOfUnreceivedMessagesFromOneSender)
+    public void EnsureSendingMessagesIsAllowed(IdentityAddress activeIdentity, int numberOfUnreceivedMessagesFromActiveIdentity, int maxNumberOfUnreceivedMessagesFromOneSender)
     {
         if (Status != RelationshipStatus.Active)
-            throw new DomainException(DomainErrors.RelationshipToRecipientNotActive(To));
+            throw new DomainException(DomainErrors.RelationshipToRecipientNotActive(GetPeerOf(activeIdentity)));
 
         if (numberOfUnreceivedMessagesFromActiveIdentity >= maxNumberOfUnreceivedMessagesFromOneSender)
             throw new DomainException(DomainErrors.MaxNumberOfUnreceivedMessagesReached(To));
@@ -47,6 +47,11 @@ public class Relationship : Entity
     public static Relationship LoadForTesting(RelationshipId id, IdentityAddress from, IdentityAddress to, DateTime createdAt, RelationshipStatus status)
     {
         return new Relationship(id, from, to, createdAt, status);
+    }
+
+    private IdentityAddress GetPeerOf(IdentityAddress activeIdentity)
+    {
+        return From == activeIdentity ? To : From;
     }
 }
 

--- a/Modules/Messages/test/Messages.Domain.Tests/ImplicitUsings.cs
+++ b/Modules/Messages/test/Messages.Domain.Tests/ImplicitUsings.cs
@@ -1,3 +1,3 @@
-﻿global using static Backbone.UnitTestTools.Data.TestDataGenerator;
+﻿global using FluentAssertions;
 global using Xunit;
-global using FluentAssertions;
+global using static Backbone.UnitTestTools.Data.TestDataGenerator;

--- a/Modules/Messages/test/Messages.Domain.Tests/ImplicitUsings.cs
+++ b/Modules/Messages/test/Messages.Domain.Tests/ImplicitUsings.cs
@@ -1,0 +1,3 @@
+﻿global using static Backbone.UnitTestTools.Data.TestDataGenerator;
+global using Xunit;
+global using FluentAssertions;

--- a/Modules/Messages/test/Messages.Domain.Tests/Relationships/RelationshipTests.cs
+++ b/Modules/Messages/test/Messages.Domain.Tests/Relationships/RelationshipTests.cs
@@ -3,9 +3,6 @@ using Backbone.DevelopmentKit.Identity.ValueObjects;
 using Backbone.Modules.Messages.Domain.Entities;
 using Backbone.Modules.Messages.Domain.Ids;
 using Backbone.UnitTestTools.BaseClasses;
-using Backbone.UnitTestTools.Data;
-using FluentAssertions;
-using Xunit;
 
 namespace Backbone.Modules.Messages.Domain.Tests.Relationships;
 
@@ -18,7 +15,7 @@ public class RelationshipTests : AbstractTestsBase
         var relationship = CreateRelationship(RelationshipStatus.Pending);
 
         // Act
-        var acting = () => relationship.EnsureSendingMessagesIsAllowed(0, 5);
+        var acting = () => relationship.EnsureSendingMessagesIsAllowed(CreateRandomIdentityAddress(), 0, 5);
 
         // Assert
         acting.Should().Throw<DomainException>().Which.Code.Should().Be("error.platform.validation.message.relationshipToRecipientNotActive");
@@ -31,7 +28,7 @@ public class RelationshipTests : AbstractTestsBase
         var relationship = CreateRelationship();
 
         // Act
-        var acting = () => relationship.EnsureSendingMessagesIsAllowed(5, 5);
+        var acting = () => relationship.EnsureSendingMessagesIsAllowed(CreateRandomIdentityAddress(), 5, 5);
 
         // Assert
         acting.Should().Throw<DomainException>().Which.Code.Should().Be("error.platform.validation.message.maxNumberOfUnreceivedMessagesReached");
@@ -44,7 +41,7 @@ public class RelationshipTests : AbstractTestsBase
         var relationship = CreateRelationship(RelationshipStatus.Terminated);
 
         // Act
-        var acting = () => relationship.EnsureSendingMessagesIsAllowed(0, 5);
+        var acting = () => relationship.EnsureSendingMessagesIsAllowed(CreateRandomIdentityAddress(), 0, 5);
 
         // Assert
         acting.Should().Throw<DomainException>().Which.Code.Should().Be("error.platform.validation.message.relationshipToRecipientNotActive");
@@ -61,8 +58,8 @@ public class RelationshipTests : AbstractTestsBase
         RelationshipStatus? status = null)
     {
         relationshipId ??= "REL00000000000000000";
-        from ??= TestDataGenerator.CreateRandomIdentityAddress();
-        to ??= TestDataGenerator.CreateRandomIdentityAddress();
+        from ??= CreateRandomIdentityAddress();
+        to ??= CreateRandomIdentityAddress();
         createdAt ??= DateTime.UtcNow;
         status ??= RelationshipStatus.Active;
 


### PR DESCRIPTION
# Readiness checklist

-   [ ] I added/updated unit tests.
-   [ ] I added/updated integration tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.
