### PR TITLE
Creation of test users fails due to minimum password length

### DIFF
--- a/Applications/DatabaseMigrator/test/DatabaseMigrator.Tests/MigrationReaderTests.cs
+++ b/Applications/DatabaseMigrator/test/DatabaseMigrator.Tests/MigrationReaderTests.cs
@@ -4,7 +4,7 @@ using Testcontainers.PostgreSql;
 
 namespace Backbone.DatabaseMigrator.Tests;
 
-public class MigrationReaderTests
+public class MigrationReaderTests : AbstractTestsBase
 {
     [Fact]
     public async Task Returns_migrations_in_correct_order()

--- a/Applications/IdentityDeletionJobs/test/Job.IdentityDeletion.Tests.Integration/ActualDeletionWorkerTests.cs
+++ b/Applications/IdentityDeletionJobs/test/Job.IdentityDeletion.Tests.Integration/ActualDeletionWorkerTests.cs
@@ -8,7 +8,6 @@ using Backbone.Modules.Messages.Infrastructure.Persistence.Database;
 using Backbone.Modules.Relationships.Domain.Aggregates.RelationshipTemplates;
 using Backbone.Modules.Relationships.Infrastructure.Persistence.Database;
 using Backbone.Tooling;
-using Backbone.UnitTestTools.Data;
 using Backbone.UnitTestTools.Extensions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -17,7 +16,7 @@ using Relationship = Backbone.Modules.Relationships.Domain.Aggregates.Relationsh
 
 namespace Backbone.Job.IdentityDeletion.Tests.Integration;
 
-public class ActualDeletionWorkerTests
+public class ActualDeletionWorkerTests : AbstractTestsBase
 {
     private readonly IHost _host;
 

--- a/Backbone.Tests.ArchUnit/Backbone.Tests.ArchUnit.csproj
+++ b/Backbone.Tests.ArchUnit/Backbone.Tests.ArchUnit.csproj
@@ -21,6 +21,18 @@
     </ItemGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\Applications\AdminApi\src\AdminApi.Infrastructure.Database.Postgres\AdminApi.Infrastructure.Database.Postgres.csproj" />
+        <ProjectReference Include="..\Applications\AdminApi\src\AdminApi.Infrastructure.Database.SqlServer\AdminApi.Infrastructure.Database.SqlServer.csproj" />
+        <ProjectReference Include="..\Applications\AdminApi\src\AdminApi.Infrastructure\AdminApi.Infrastructure.csproj" />
+        <ProjectReference Include="..\Applications\AdminApi\src\AdminApi\AdminApi.csproj" />
+        <ProjectReference Include="..\Applications\AdminCli\src\AdminCli\AdminCli.csproj" />
+        <ProjectReference Include="..\Applications\DatabaseMigrator\src\DatabaseMigrator\DatabaseMigrator.csproj" />
+        <ProjectReference Include="..\Applications\DatabaseMigrator\test\DatabaseMigrator.Tests\DatabaseMigrator.Tests.csproj" />
+        <ProjectReference Include="..\Applications\HealthCheck\src\HealthCheck.csproj" />
+        <ProjectReference Include="..\Applications\IdentityDeletionJobs\test\Job.IdentityDeletion.Tests.Integration\Job.IdentityDeletion.Tests.Integration.csproj" />
+        <ProjectReference Include="..\Applications\SseServer\src\SseServer\SseServer.csproj" />
+        <ProjectReference Include="..\Applications\SseServer\test\SseServerTests\SseServerTests.csproj" />
+        <ProjectReference Include="..\BuildingBlocks\src\BuildingBlocks.SDK\BuildingBlocks.SDK.csproj" />
         <ProjectReference Include="..\BuildingBlocks\src\UnitTestTools\UnitTestTools.csproj" />
         <ProjectReference Include="..\BuildingBlocks\test\BuildingBlocks.Application.Tests\BuildingBlocks.Application.Tests.csproj" />
         <ProjectReference Include="..\BuildingBlocks\test\BuildingBlocks.Infrastructure.Tests\BuildingBlocks.Infrastructure.Tests.csproj" />
@@ -30,12 +42,15 @@
         <ProjectReference Include="..\Applications\ConsumerApi\src\ConsumerApi.csproj" />
         <ProjectReference Include="..\Applications\EventHandlerService\test\EventHandlerService.Tests\EventHandlerService.Tests.csproj" />
         <ProjectReference Include="..\Applications\IdentityDeletionJobs\test\Job.IdentityDeletion.Tests\Job.IdentityDeletion.Tests.csproj" />
+        <ProjectReference Include="..\Modules\Challenges\src\Challenges.Jobs.Cleanup\Challenges.Jobs.Cleanup.csproj" />
+        <ProjectReference Include="..\Modules\Challenges\test\Challenges.Application.Tests\Challenges.Application.Tests.csproj" />
         <ProjectReference Include="..\Modules\Devices\test\Devices.Application.Tests\Devices.Application.Tests.csproj" />
         <ProjectReference Include="..\Modules\Devices\test\Devices.Domain.Tests\Devices.Domain.Tests.csproj" />
         <ProjectReference Include="..\Modules\Devices\test\Devices.Infrastructure.Tests\Devices.Infrastructure.Tests.csproj" />
         <ProjectReference Include="..\Modules\Files\test\Files.Application.Tests\Files.Application.Tests.csproj" />
         <ProjectReference Include="..\Modules\Files\test\Files.Infrastructure.Tests\Files.Infrastructure.Tests.csproj" />
         <ProjectReference Include="..\Applications\FilesSanityCheck\test\Files.Jobs.SanityCheck.Tests\FilesSanityCheck.Tests.csproj" />
+        <ProjectReference Include="..\Modules\Messages\src\Messages.Common\Messages.Common.csproj" />
         <ProjectReference Include="..\Modules\Messages\test\Messages.Application.Tests\Messages.Application.Tests.csproj" />
         <ProjectReference Include="..\Modules\Messages\test\Messages.Domain.Tests\Messages.Domain.Tests.csproj" />
         <ProjectReference Include="..\Modules\Quotas\test\Quotas.Application.Tests\Quotas.Application.Tests.csproj" />
@@ -44,5 +59,6 @@
         <ProjectReference Include="..\Modules\Synchronization\test\Synchronization.Application.Tests\Synchronization.Application.Tests.csproj" />
         <ProjectReference Include="..\Modules\Synchronization\test\Synchronization.Domain.Tests\Synchronization.Domain.Tests.csproj" />
         <ProjectReference Include="..\Modules\Tokens\test\Tokens.Application.Tests\Tokens.Application.Tests.csproj" />
+        <ProjectReference Include="..\Modules\Tokens\test\Tokens.Domain.Tests\Tokens.Domain.Tests.csproj" />
     </ItemGroup>
 </Project>

--- a/Modules/Devices/src/Devices.Application/Users/Commands/SeedTestUsers/Handler.cs
+++ b/Modules/Devices/src/Devices.Application/Users/Commands/SeedTestUsers/Handler.cs
@@ -26,7 +26,7 @@ public class Handler : IRequestHandler<SeedTestUsersCommand>
         var identityA = Identity.CreateTestIdentity(IdentityAddress.Create([1, 1, 1, 1, 1], _applicationOptions.DidDomainName), [1, 1, 1, 1, 1], basicTier!.Id, "USRa");
         var identityB = Identity.CreateTestIdentity(IdentityAddress.Create([2, 2, 2, 2, 2], _applicationOptions.DidDomainName), [2, 2, 2, 2, 2], basicTier.Id, "USRb");
 
-        await _identitiesRepository.Add(identityA, "a");
-        await _identitiesRepository.Add(identityB, "b");
+        await _identitiesRepository.Add(identityA, "aaaaaaaaaa");
+        await _identitiesRepository.Add(identityB, "bbbbbbbbbb");
     }
 }

--- a/Modules/Tokens/test/Tokens.Domain.Tests/Tests/TokenCanBeCollectedUsingPasswordTests.cs
+++ b/Modules/Tokens/test/Tokens.Domain.Tests/Tests/TokenCanBeCollectedUsingPasswordTests.cs
@@ -2,7 +2,7 @@
 
 namespace Backbone.Modules.Tokens.Domain.Tests.Tests;
 
-public class TokenCanBeCollectedUsingPasswordTests
+public class TokenCanBeCollectedUsingPasswordTests : AbstractTestsBase
 {
     [Fact]
     public void Can_collect_without_a_password_when_no_password_is_defined()


### PR DESCRIPTION
# Readiness checklist

-   [x] I added/updated unit tests.
-   [ ] I added/updated integration tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.

For context: in the past, our test users USRa and USRb had a password length of 1. This was possible because we created them manually instead of via the ASP.NET Identity's UserManager. Recently we changed this. No we reuse the same code we use to creat real users. 

Since locally we have different requirements for password lengths, this never showed up. But I just wanted to set up a new production environment and noticed that there is an error when creating the test users that complains about the password not being long enough.

This PR changes the default passwords from `a` and `b` to `aaaaaaaaaa` and `bbbbbbbbbb` respectively (see Modules/Devices/src/Devices.Application/Users/Commands/SeedTestUsers/Handler.cs). The other files are just small test changes, because I noticed that some of our tests don't match our convention that they should inherit from `AbstractTestsBase`.