### PR TITLE
Server sent events are not sent

### DIFF
--- a/Applications/SseServer/src/SseServer/Controllers/SseController.cs
+++ b/Applications/SseServer/src/SseServer/Controllers/SseController.cs
@@ -25,7 +25,7 @@ public class SseController : ControllerBase
 
     [HttpGet("/api/v1/sse")]
     [Authorize]
-    public async Task<IActionResult> Subscribe()
+    public async Task Subscribe()
     {
         var address = _userContext.GetAddress().Value;
 
@@ -56,8 +56,7 @@ public class SseController : ControllerBase
         }
         catch (ClientAlreadyRegisteredException)
         {
-            return BadRequest(HttpError.ForProduction("error.platform.sseClientAlreadyRegistered",
-                "An SSE client for your identity is already registered. You can only register once per identity.", ""));
+            // if it is already registered, everything is fine
         }
         catch (OperationCanceledException)
         {
@@ -72,8 +71,6 @@ public class SseController : ControllerBase
             _eventQueue.Deregister(address);
             await _mediator.Send(new DeleteDeviceRegistrationCommand());
         }
-
-        return Ok();
     }
 }
 

--- a/Applications/SseServer/src/SseServer/Controllers/SseController.cs
+++ b/Applications/SseServer/src/SseServer/Controllers/SseController.cs
@@ -59,6 +59,10 @@ public class SseController : ControllerBase
             return BadRequest(HttpError.ForProduction("error.platform.sseClientAlreadyRegistered",
                 "An SSE client for your identity is already registered. You can only register once per identity.", ""));
         }
+        catch (OperationCanceledException)
+        {
+            // this is expected when the client disconnects
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "An error occurred while processing the request.");

--- a/Applications/SseServer/src/SseServer/Extensions/IServiceCollectionExtensions.cs
+++ b/Applications/SseServer/src/SseServer/Extensions/IServiceCollectionExtensions.cs
@@ -65,7 +65,7 @@ public static class IServiceCollectionExtensions
                 options.JsonSerializerOptions.DictionaryKeyPolicy = JsonNamingPolicy.CamelCase;
             });
 
-        services.AddAuthentication().AddJwtBearer(options =>
+        services.AddAuthentication().AddJwtBearer("default", options =>
         {
             var privateKeyBytes = Convert.FromBase64String(configuration.Authentication.JwtSigningCertificate);
 #pragma warning disable SYSLIB0057 // The constructor is obsolete. But I didn't manage to get the suggested alternative to work.
@@ -75,7 +75,13 @@ public static class IServiceCollectionExtensions
             options.TokenValidationParameters.ValidateIssuer = false;
             options.TokenValidationParameters.ValidateAudience = false;
         });
-        services.AddAuthorization();
+
+        services.AddAuthorizationBuilder()
+            .AddDefaultPolicy("default", policy =>
+            {
+                policy.AddAuthenticationSchemes("default");
+                policy.RequireAuthenticatedUser();
+            });
 
         services.AddHttpContextAccessor();
 

--- a/Applications/SseServer/src/SseServer/Program.cs
+++ b/Applications/SseServer/src/SseServer/Program.cs
@@ -13,7 +13,6 @@ using Backbone.SseServer.Extensions;
 using Backbone.Tooling.Extensions;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.Options;
-using Microsoft.IdentityModel.Logging;
 using Serilog;
 using Serilog.Exceptions;
 using Serilog.Exceptions.Core;
@@ -142,9 +141,6 @@ static void Configure(WebApplication app)
             .AddCustomHeader("Strict-Transport-Security", "max-age=5184000; includeSubDomains")
             .AddCustomHeader("X-Frame-Options", "Deny")
     );
-
-    if (app.Environment.IsDevelopment())
-        IdentityModelEventSource.ShowPII = true;
 
     app.UseAuthentication().UseAuthorization();
 

--- a/Applications/SseServer/src/SseServer/Program.cs
+++ b/Applications/SseServer/src/SseServer/Program.cs
@@ -117,6 +117,8 @@ static void ConfigureServices(IServiceCollection services, IConfiguration config
         options.KnownProxies.Clear();
     });
 
+    services.AddCustomIdentity(environment);
+
     services.AddPushNotifications(parsedConfiguration.Modules.Devices.Infrastructure.PushNotifications);
 }
 

--- a/Applications/SseServer/src/SseServer/Program.cs
+++ b/Applications/SseServer/src/SseServer/Program.cs
@@ -75,7 +75,7 @@ static WebApplication CreateApp(string[] args)
         )
         .UseServiceProviderFactory(new AutofacServiceProviderFactory());
 
-    ConfigureServices(builder.Services, builder.Configuration);
+    ConfigureServices(builder.Services, builder.Configuration, builder.Environment);
 
     var app = builder.Build();
     Configure(app);
@@ -88,7 +88,7 @@ static WebApplication CreateApp(string[] args)
     return app;
 }
 
-static void ConfigureServices(IServiceCollection services, IConfiguration configuration)
+static void ConfigureServices(IServiceCollection services, IConfiguration configuration, IWebHostEnvironment environment)
 {
     services.ConfigureAndValidate<Configuration>(configuration.Bind);
 
@@ -151,8 +151,6 @@ static void Configure(WebApplication app)
     app.MapControllers();
 
     app.MapHealthChecks("/health");
-
-    app.UseResponseCaching();
 }
 
 static void LoadConfiguration(WebApplicationBuilder webApplicationBuilder, string[] strings)

--- a/Modules/Devices/src/Devices.Infrastructure/PushNotifications/Connectors/Sse/SseMessageBuilder.cs
+++ b/Modules/Devices/src/Devices.Infrastructure/PushNotifications/Connectors/Sse/SseMessageBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System.Net.Http.Json;
 using System.Text.Json.Serialization;
+using System.Web;
 
 namespace Backbone.Modules.Devices.Infrastructure.PushNotifications.Connectors.Sse;
 
@@ -16,7 +17,7 @@ public class SseMessageBuilder
 
     public HttpRequestMessage Build()
     {
-        var request = new HttpRequestMessage(HttpMethod.Post, $"{_recipient}/events")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"{HttpUtility.UrlEncode(_recipient)}/events")
         {
             Content = JsonContent.Create(new EventPayload(_eventName))
         };


### PR DESCRIPTION
# Readiness checklist

-   [ ] I added/updated unit tests.
-   [ ] I added/updated integration tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.

This PR fixes multiple issues with server sent events:
* First and foremost, it URL-encodes the enmeshed address in the URL. Otherwise the HttpClient thinks that the `did:` part should represent a URL scheme like `http:` and fails, because it doesn't support this scheme. See https://github.com/nmshd/backbone/commit/2ed3e965e21bc52629aa1e20087bea018707b8ae for the corresponding commit.
* Due to a recent change to the `PushService`, it is now required to add ASP.NET Identity to the service collection. See https://github.com/nmshd/backbone/commit/bceae43aea3907f9e12850e197c2f1e0a076250c
* For some reason, I had to replace `AddAuthorization` with `AddAuthorizationBuilder`. Before that, a call to the `/api/v1/sse` route returned a 302 (a redirect to the auth endpoint). See https://github.com/nmshd/backbone/commit/64d63cce8290a2db3c88f2a7139112e2083688a5.
* I catch the `OperationCancelledException` in order to prevent it from being logged (this caused a lot of noise before). See https://github.com/nmshd/backbone/commit/5e8b2f9c7af196967ea8849acfc9e9721456c9c1.
* I removed the return value from the `SseController.Subscribe` method. Before it threw an exception in case of a cancelled request, because it tried to return `Ok` even though there was no response stream to write to (because the request was cancelled). See https://github.com/nmshd/backbone/commit/3d47ac7971bd2b0fbc4462ff019c3adadba619eb.
