### PR TITLE
Possibility for the user to override the length of the grace period when starting an identity deletion process

### DIFF
--- a/Modules/Devices/src/Devices.Application/Identities/Commands/StartDeletionProcessAsOwner/Handler.cs
+++ b/Modules/Devices/src/Devices.Application/Identities/Commands/StartDeletionProcessAsOwner/Handler.cs
@@ -27,7 +27,7 @@ public class Handler : IRequestHandler<StartDeletionProcessAsOwnerCommand, Start
     {
         var identity = await _identitiesRepository.FindByAddress(_userContext.GetAddress(), cancellationToken, true) ?? throw new NotFoundException(nameof(Identity));
 
-        var deletionProcess = identity.StartDeletionProcessAsOwner(_userContext.GetDeviceId());
+        var deletionProcess = identity.StartDeletionProcessAsOwner(_userContext.GetDeviceId(), request.LengthOfGracePeriodInDays);
 
         try
         {

--- a/Modules/Devices/src/Devices.Application/Identities/Commands/StartDeletionProcessAsOwner/StartDeletionProcessAsOwnerCommand.cs
+++ b/Modules/Devices/src/Devices.Application/Identities/Commands/StartDeletionProcessAsOwner/StartDeletionProcessAsOwnerCommand.cs
@@ -2,4 +2,7 @@ using MediatR;
 
 namespace Backbone.Modules.Devices.Application.Identities.Commands.StartDeletionProcessAsOwner;
 
-public class StartDeletionProcessAsOwnerCommand : IRequest<StartDeletionProcessAsOwnerResponse>;
+public class StartDeletionProcessAsOwnerCommand : IRequest<StartDeletionProcessAsOwnerResponse>
+{
+    public double? LengthOfGracePeriodInDays { get; set; }
+}

--- a/Modules/Devices/src/Devices.ConsumerApi/Controllers/IdentitiesController.cs
+++ b/Modules/Devices/src/Devices.ConsumerApi/Controllers/IdentitiesController.cs
@@ -70,9 +70,10 @@ public class IdentitiesController : ApiControllerBase
     [HttpPost("Self/DeletionProcesses")]
     [ProducesResponseType(typeof(HttpResponseEnvelopeResult<StartDeletionProcessAsOwnerResponse>), StatusCodes.Status201Created)]
     [ProducesError(StatusCodes.Status400BadRequest)]
-    public async Task<IActionResult> StartDeletionProcess(CancellationToken cancellationToken)
+    public async Task<IActionResult> StartDeletionProcess(StartDeletionProcessAsOwnerCommand? request, CancellationToken cancellationToken)
     {
-        var response = await _mediator.Send(new StartDeletionProcessAsOwnerCommand(), cancellationToken);
+        request ??= new StartDeletionProcessAsOwnerCommand();
+        var response = await _mediator.Send(request, cancellationToken);
         return Created("", response);
     }
 

--- a/Modules/Devices/src/Devices.Domain/Entities/Identities/Identity.cs
+++ b/Modules/Devices/src/Devices.Domain/Entities/Identities/Identity.cs
@@ -130,14 +130,14 @@ public class Identity : Entity
         return deletionProcess;
     }
 
-    public IdentityDeletionProcess StartDeletionProcessAsOwner(DeviceId asDevice)
+    public IdentityDeletionProcess StartDeletionProcessAsOwner(DeviceId asDevice, double? lengthOfGracePeriodInDays = null)
     {
         EnsureNoActiveProcessExists();
         EnsureIdentityOwnsDevice(asDevice);
 
         TierIdBeforeDeletion = TierId;
 
-        var deletionProcess = IdentityDeletionProcess.StartAsOwner(Address, asDevice);
+        var deletionProcess = IdentityDeletionProcess.StartAsOwner(Address, asDevice, lengthOfGracePeriodInDays);
         _deletionProcesses.Add(deletionProcess);
 
         DeletionGracePeriodEndsAt = deletionProcess.GracePeriodEndsAt;

--- a/Modules/Devices/src/Devices.Domain/Entities/Identities/IdentityDeletionProcess.cs
+++ b/Modules/Devices/src/Devices.Domain/Entities/Identities/IdentityDeletionProcess.cs
@@ -31,13 +31,13 @@ public class IdentityDeletionProcess : Entity
         RaiseDomainEvent(new IdentityDeletionProcessStartedDomainEvent(createdBy, Id, null));
     }
 
-    private IdentityDeletionProcess(IdentityAddress createdBy, DeviceId createdByDevice)
+    private IdentityDeletionProcess(IdentityAddress createdBy, DeviceId createdByDevice, double? lengthOfGracePeriodInDays)
     {
         Id = IdentityDeletionProcessId.Generate();
         IdentityAddress = null!;
         CreatedAt = SystemTime.UtcNow;
 
-        ApproveInternally(createdBy, createdByDevice);
+        ApproveInternally(createdBy, createdByDevice, lengthOfGracePeriodInDays);
 
         _auditLog = [IdentityDeletionProcessAuditLogEntry.ProcessStartedByOwner(Id, createdBy, createdByDevice)];
     }
@@ -81,9 +81,9 @@ public class IdentityDeletionProcess : Entity
         return new IdentityDeletionProcess(createdBy, DeletionProcessStatus.WaitingForApproval);
     }
 
-    public static IdentityDeletionProcess StartAsOwner(IdentityAddress createdBy, DeviceId createdByDeviceId)
+    public static IdentityDeletionProcess StartAsOwner(IdentityAddress createdBy, DeviceId createdByDeviceId, double? lengthOfGracePeriodInDays)
     {
-        return new IdentityDeletionProcess(createdBy, createdByDeviceId);
+        return new IdentityDeletionProcess(createdBy, createdByDeviceId, lengthOfGracePeriodInDays);
     }
 
     public bool IsActive()
@@ -150,11 +150,12 @@ public class IdentityDeletionProcess : Entity
         _auditLog.Add(IdentityDeletionProcessAuditLogEntry.ProcessApproved(Id, address, approvedByDevice));
     }
 
-    private void ApproveInternally(IdentityAddress address, DeviceId createdByDevice)
+    private void ApproveInternally(IdentityAddress address, DeviceId createdByDevice, double? lengthOfGracePeriodInDays = null)
     {
+        lengthOfGracePeriodInDays ??= IdentityDeletionConfiguration.Instance.LengthOfGracePeriodInDays;
         ApprovedAt = SystemTime.UtcNow;
         ApprovedByDevice = createdByDevice;
-        GracePeriodEndsAt = SystemTime.UtcNow.AddDays(IdentityDeletionConfiguration.Instance.LengthOfGracePeriodInDays);
+        GracePeriodEndsAt = SystemTime.UtcNow.AddDays(lengthOfGracePeriodInDays.Value);
         ChangeStatus(DeletionProcessStatus.Approved, address, address);
     }
 

--- a/Modules/Devices/test/Devices.Domain.Tests/Identities/StartDeletionProcessAsOwnerTests.cs
+++ b/Modules/Devices/test/Devices.Domain.Tests/Identities/StartDeletionProcessAsOwnerTests.cs
@@ -99,6 +99,22 @@ public class StartDeletionProcessAsOwnerTests : AbstractTestsBase
         identityToBeDeletedDomainEvent.IdentityAddress.Should().Be(activeIdentity.Address);
     }
 
+    [Fact]
+    public void Passing_a_lengthOfDeletionGracePeriod_overrides_the_configured_value()
+    {
+        //Arrange
+        var activeIdentity = TestDataGenerator.CreateIdentity();
+        var activeDevice = activeIdentity.Devices[0];
+        SystemTime.Set("2000-01-01");
+
+        //Act
+        activeIdentity.StartDeletionProcessAsOwner(activeDevice.Id, 1);
+
+        // Assert
+        activeIdentity.DeletionGracePeriodEndsAt.Should().Be(DateTime.Parse("2000-01-02"));
+        activeIdentity.DeletionProcesses.First().GracePeriodEndsAt.Should().Be(DateTime.Parse("2000-01-02"));
+    }
+
     private static void AssertDeletionProcessWasStarted(Identity activeIdentity)
     {
         activeIdentity.DeletionProcesses.Should().HaveCount(1);


### PR DESCRIPTION
# Readiness checklist

-   [x] I added/updated unit tests.
-   [ ] I added/updated integration tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.
