### PR TITLE
Consumer Api: Identities with expired grace period shouldn't be able to log in

### DIFF
--- a/Applications/ConsumerApi/src/Controllers/AuthorizationController.cs
+++ b/Applications/ConsumerApi/src/Controllers/AuthorizationController.cs
@@ -49,7 +49,7 @@ public class AuthorizationController : ApiControllerBase
                 ApplicationErrors.Authentication.InvalidOAuthRequest("missing username"));
 
         var user = await _userManager.FindByNameAsync(request.Username!);
-        if (user == null)
+        if (user == null || user.Device.Identity.IsGracePeriodOver)
             return InvalidUserCredentials();
 
         if (request.Password.IsNullOrEmpty())


### PR DESCRIPTION
# Readiness checklist

-   [ ] I added/updated unit tests.
-   [ ] I added/updated integration tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.
