### PR TITLE
Consumer Api: Deleting an identity with an already decomposed relationship throws an error

### DIFF
--- a/Modules/Relationships/src/Relationships.Domain/Aggregates/Relationships/Relationship.DecomposeDueToIdentityDeletionTests.cs
+++ b/Modules/Relationships/src/Relationships.Domain/Aggregates/Relationships/Relationship.DecomposeDueToIdentityDeletionTests.cs
@@ -31,19 +31,6 @@ public class RelationshipDecomposeDueToIdentityDeletionTests : AbstractTestsBase
     }
 
     [Fact]
-    public void Decomposition_can_not_be_called_by_the_same_identity_twice()
-    {
-        // Arrange
-        var relationship = CreateRelationshipDecomposedByFrom(IDENTITY_1, IDENTITY_2);
-
-        // Act
-        var acting = () => relationship.DecomposeDueToIdentityDeletion(IDENTITY_1, DID_DOMAIN_NAME);
-
-        // Assert
-        acting.Should().Throw<DomainException>().WithError("error.platform.validation.relationship.relationshipAlreadyDecomposed");
-    }
-
-    [Fact]
     public void Decomposition_can_not_be_performed_by_other_identities()
     {
         // Arrange

--- a/Modules/Relationships/src/Relationships.Domain/Aggregates/Relationships/Relationship.cs
+++ b/Modules/Relationships/src/Relationships.Domain/Aggregates/Relationships/Relationship.cs
@@ -306,7 +306,8 @@ public class Relationship : Entity
     public void DecomposeDueToIdentityDeletion(IdentityAddress identityToBeDeleted, string didDomainName)
     {
         EnsureHasParticipant(identityToBeDeleted);
-        EnsureRelationshipNotDecomposedBy(identityToBeDeleted);
+
+        if (From == identityToBeDeleted && FromHasDecomposed || To == identityToBeDeleted && ToHasDecomposed) return;
 
         if (Status is RelationshipStatus.DeletionProposed)
             DecomposeAsSecondParticipant(identityToBeDeleted, null, RelationshipAuditLogEntryReason.DecompositionDueToIdentityDeletion);


### PR DESCRIPTION
# Readiness checklist

-   [ ] I added/updated unit tests.
-   [ ] I added/updated integration tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.
