### PR TITLE
It is possible to cancel deletion processes with expired grace periods

### DIFF
--- a/Modules/Devices/src/Devices.Domain/DomainErrors.cs
+++ b/Modules/Devices/src/Devices.Domain/DomainErrors.cs
@@ -64,6 +64,12 @@ public static class DomainErrors
             "The deletion via this deletion process cannot be started because the grace period has not yet expired.");
     }
 
+    public static DomainError GracePeriodHasAlreadyExpired()
+    {
+        return new DomainError("error.platform.validation.device.gracePeriodHasAlreadyExpired",
+            "You cannot perform this action, because the grace period of this deletion process has already expired.");
+    }
+
     public static DomainError DeletionProcessMustBePastDueApproval()
     {
         return new DomainError("error.platform.validation.device.noDeletionProcessIsPastDueApproval", "No deletion process is past due approval.");

--- a/Modules/Devices/src/Devices.Domain/Entities/Identities/IdentityDeletionProcess.cs
+++ b/Modules/Devices/src/Devices.Domain/Entities/Identities/IdentityDeletionProcess.cs
@@ -181,6 +181,9 @@ public class IdentityDeletionProcess : Entity
         if (Status != DeletionProcessStatus.Approved)
             throw new DomainException(DomainErrors.DeletionProcessMustBeInStatus(DeletionProcessStatus.Approved));
 
+        if (GracePeriodEndsAt < SystemTime.UtcNow)
+            throw new DomainException(DomainErrors.GracePeriodHasAlreadyExpired());
+
         ChangeStatus(DeletionProcessStatus.Cancelled, address, address);
         CancelledAt = SystemTime.UtcNow;
         CancelledByDevice = cancelledByDevice;

--- a/Modules/Devices/test/Devices.Domain.Tests/Identities/CancelDeletionProcessAsOwnerTests.cs
+++ b/Modules/Devices/test/Devices.Domain.Tests/Identities/CancelDeletionProcessAsOwnerTests.cs
@@ -59,6 +59,21 @@ public class CancelDeletionProcessAsOwnerTests : AbstractTestsBase
     }
 
     [Fact]
+    public void Throws_when_grace_period_has_expired()
+    {
+        // Arrange
+        var identity = TestDataGenerator.CreateIdentityWithApprovedDeletionProcess();
+
+        SystemTime.Set(DateTime.UtcNow.AddDays(IdentityDeletionConfiguration.Instance.LengthOfGracePeriodInDays));
+
+        // Act
+        var acting = () => identity.CancelDeletionProcessAsOwner(identity.DeletionProcesses[0].Id, identity.Devices[0].Id);
+
+        // Assert
+        acting.Should().Throw<DomainException>().Which.Code.Should().Be("error.platform.validation.device.gracePeriodHasAlreadyExpired");
+    }
+
+    [Fact]
     public void Raises_domain_events()
     {
         // Arrange


### PR DESCRIPTION
# Readiness checklist

-   [x] I added/updated unit tests.
-   [ ] I added/updated integration tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.
