### PR TITLE
Push notifications for new datawallet modifications are displayed with an empty content (FCM) or don't arrive at all (APNs)

### DIFF
--- a/Modules/Devices/src/Devices.Infrastructure/Translations/Resources.de.resx
+++ b/Modules/Devices/src/Devices.Infrastructure/Translations/Resources.de.resx
@@ -78,4 +78,10 @@
     <data name="BackupDeviceUsedPushNotification.Body" xml:space="preserve">
         <value>Ihr Wiederherstellungsgerät wurde benutzt.</value>
     </data>
+    <data name="DatawalletModificationsCreatedPushNotification.Title" xml:space="preserve">
+        <value>Neuigkeiten verfügbar</value>
+    </data>
+    <data name="DatawalletModificationsCreatedPushNotification.Body" xml:space="preserve">
+        <value>Es sind Neuigkeiten in der App verfügbar.</value>
+    </data>
 </root>

--- a/Modules/Devices/src/Devices.Infrastructure/Translations/Resources.it.resx
+++ b/Modules/Devices/src/Devices.Infrastructure/Translations/Resources.it.resx
@@ -78,4 +78,10 @@
     <data name="BackupDeviceUsedPushNotification.Body" xml:space="preserve">
         <value>Il dispositivo di backup è stato utilizzato.</value>
     </data>
+    <data name="DatawalletModificationsCreatedPushNotification.Body" xml:space="preserve">
+        <value>Nuovi aggiornamenti sono disponibili nell'app.</value>
+    </data>
+    <data name="DatawalletModificationsCreatedPushNotification.Title" xml:space="preserve">
+        <value>Aggiornamenti disponibili</value>
+    </data>
 </root>

--- a/Modules/Devices/src/Devices.Infrastructure/Translations/Resources.pt.resx
+++ b/Modules/Devices/src/Devices.Infrastructure/Translations/Resources.pt.resx
@@ -177,4 +177,10 @@
     <data name="BackupDeviceUsedPushNotification.Body" xml:space="preserve">
         <value>O seu dispositivo de cópia de segurança foi utilizado.</value>
     </data>
+    <data name="DatawalletModificationsCreatedPushNotification.Body" xml:space="preserve">
+        <value>Há atualizações disponíveis na aplicação.</value>
+    </data>
+    <data name="DatawalletModificationsCreatedPushNotification.Title" xml:space="preserve">
+        <value>Atualizações Disponíveis</value>
+    </data>
 </root>

--- a/Modules/Devices/src/Devices.Infrastructure/Translations/Resources.resx
+++ b/Modules/Devices/src/Devices.Infrastructure/Translations/Resources.resx
@@ -178,9 +178,9 @@
         <value>Your backup device was used.</value>
     </data>
     <data name="DatawalletModificationsCreatedPushNotification.Body" xml:space="preserve">
-        <value />
+        <value>New updates are available in the app.</value>
     </data>
     <data name="DatawalletModificationsCreatedPushNotification.Title" xml:space="preserve">
-        <value />
+        <value>Updates available</value>
     </data>
 </root>


### PR DESCRIPTION
# Readiness checklist

-   [ ] I added/updated unit tests.
-   [ ] I added/updated integration tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.
