### PR TITLE
Sanitize eventName in SSE server controller before logging it

### DIFF
--- a/Applications/SseServer/src/SseServer/Controllers/EventQueue.cs
+++ b/Applications/SseServer/src/SseServer/Controllers/EventQueue.cs
@@ -28,7 +28,8 @@ public class EventQueue : IEventQueue
 
     public async Task EnqueueFor(string address, string eventName, CancellationToken cancellationToken)
     {
-        _logger.LogDebug("Enqueueing event '{EventName}'", eventName);
+        var sanitizedEventName = eventName.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+        _logger.LogDebug("Enqueueing event '{EventName}'", sanitizedEventName);
 
         if (!_channels.TryGetValue(address, out var channel))
             throw new ClientNotFoundException();


### PR DESCRIPTION
Potential fix for [https://github.com/nmshd/backbone/security/code-scanning/37](https://github.com/nmshd/backbone/security/code-scanning/37)

To fix the problem, we need to sanitize the `eventName` parameter before logging it. This can be done by removing any newline characters from the `eventName` to prevent log forging. We can use the `String.Replace` method to achieve this.

- In the `EnqueueFor` method of the `EventQueue` class, sanitize the `eventName` parameter before logging it.
- Specifically, replace newline characters in the `eventName` with an empty string to ensure that no new lines are introduced in the log entry.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
