### PR TITLE
Consumer Api: Create external event when Relationship Template is allocated too many times

### DIFF
--- a/Applications/ConsumerApi/src/http/RelationshipTemplates/Get Relationship Template.bru
+++ b/Applications/ConsumerApi/src/http/RelationshipTemplates/Get Relationship Template.bru
@@ -7,9 +7,9 @@ meta {
 get {
   url: {{baseUrl}}/RelationshipTemplates/{{RelationshipTemplateId}}
   body: none
-  auth: none
+  auth: inherit
 }
 
 vars:pre-request {
-  RelationshipTemplateId: RLTdW3WlaBORnozO89RF
+  RelationshipTemplateId: RLTnhB5RewVp7wslMmo5
 }

--- a/Applications/ConsumerApi/test/ConsumerApi.Tests.Integration/Features/RelationshipTemplates/{id}/GET.feature
+++ b/Applications/ConsumerApi/test/ConsumerApi.Tests.Integration/Features/RelationshipTemplates/{id}/GET.feature
@@ -26,3 +26,11 @@ User requests a Relationship Template
           | i1 and i2       | i1            | i2          | password | i2             | password      | 200 (OK)           | non-owner is forIdentity and tries to get with correct password   |
           | i1 and i2       | i1            | i2          | password | i2             | wordpass      | 404 (Not Found)    | non-owner is forIdentity and tries to get with incorrect password |
           | i1, i2 and i3   | i1            | i2          | password | i3             | password      | 404 (Not Found)    | non-owner is forIdentity, and thirdParty tries to get             |
+
+    Scenario: Requesting a Relationship Template too many times creates an external event
+        Given Identities i1 and i2
+        And a Relationship Template rt created by i1 with 1 max allocations
+        When i2 sends a GET request to the /RelationshipTemplates/rt.Id endpoint
+        And 2 second(s) have passed
+        Then the response status code is 200 (OK)
+        And i1 recieves an ExternalEvent of type RelationshipTemplateAllocationsExhausted which contains the Relationship Template rt

--- a/Applications/ConsumerApi/test/ConsumerApi.Tests.Integration/StepDefinitions/RelationshipTemplatesStepDefinitions.cs
+++ b/Applications/ConsumerApi/test/ConsumerApi.Tests.Integration/StepDefinitions/RelationshipTemplatesStepDefinitions.cs
@@ -39,6 +39,15 @@ internal class RelationshipTemplatesStepDefinitions
             (await client.RelationshipTemplates.CreateTemplate(new CreateRelationshipTemplateRequest { Content = TestData.SOME_BYTES })).Result!;
     }
 
+    [Given($"a Relationship Template {RegexFor.SINGLE_THING} created by {RegexFor.SINGLE_THING} with {RegexFor.SINGLE_THING} max allocations")]
+    public async Task GivenARelationshipTemplateCreatedByIdentityWithMaxAllocations(string templateName, string identityName, string maxAllocations)
+    {
+        var client = _clientPool.FirstForIdentityName(identityName);
+        int? allocations = maxAllocations == "-" ? null : int.Parse(maxAllocations);
+        _relationshipTemplatesContext.CreateRelationshipTemplatesResponses[templateName] =
+            (await client.RelationshipTemplates.CreateTemplate(new CreateRelationshipTemplateRequest { Content = TestData.SOME_BYTES, MaxNumberOfAllocations = allocations })).Result!;
+    }
+
     [Given($@"Relationship Template {RegexFor.SINGLE_THING} created by {RegexFor.SINGLE_THING} with password ""([^""]*)"" and forIdentity {RegexFor.OPTIONAL_SINGLE_THING}")]
     public async Task GivenRelationshipTemplateCreatedByTokenOwnerWithPasswordAndForIdentity(string relationshipTemplateName, string identityName, string passwordString, string forIdentityName)
     {

--- a/Applications/ConsumerApi/test/ConsumerApi.Tests.Integration/StepDefinitions/SynchronizationStepDefinitions.cs
+++ b/Applications/ConsumerApi/test/ConsumerApi.Tests.Integration/StepDefinitions/SynchronizationStepDefinitions.cs
@@ -13,13 +13,15 @@ internal class SynchronizationStepDefinitions
     private readonly Dictionary<string, StartSyncRunResponse> _startSyncRunResponses = new();
     private readonly ResponseContext _responseContext;
     private readonly MessagesContext _messagesContext;
+    private readonly RelationshipTemplatesContext _relationshipTemplatesContext;
     private ApiResponse<ListExternalEventsResponse>? _listExternalEventsOfSyncRunResponse;
 
-    public SynchronizationStepDefinitions(ResponseContext responseContext, MessagesContext messagesContext, ClientPool clientPool)
+    public SynchronizationStepDefinitions(ResponseContext responseContext, MessagesContext messagesContext, ClientPool clientPool, RelationshipTemplatesContext relationshipTemplatesContext)
     {
         _responseContext = responseContext;
         _messagesContext = messagesContext;
         _clientPool = clientPool;
+        _relationshipTemplatesContext = relationshipTemplatesContext;
     }
 
     #region Given
@@ -84,6 +86,23 @@ internal class SynchronizationStepDefinitions
         externalEvents.Result.Should().Contain(e =>
             e.Type == "PeerFeatureFlagsChanged" &&
             e.Payload["peerAddress"].GetString() == peerAddress);
+    }
+
+    [Then($@"{RegexFor.SINGLE_THING} recieves an ExternalEvent of type RelationshipTemplateAllocationsExhausted which contains the Relationship Template {RegexFor.SINGLE_THING}")]
+    public async Task ThenIRecievesAnExternalEventOfTypeRelationshipTemplateAllocationsExhausted(string notifiedIdentityName, string relationshipTemplateName)
+    {
+        var client = _clientPool.FirstForIdentityName(notifiedIdentityName);
+        var syncRunResponse = await client.SyncRuns.StartSyncRun(new StartSyncRunRequest { Type = SyncRunType.ExternalEventSync }, 1);
+
+        syncRunResponse.Result.Should().NotBeNull();
+        syncRunResponse.Result!.Status.Should().Be("Created");
+        var externalEvents = await client.SyncRuns.ListExternalEventsOfSyncRun(syncRunResponse.Result!.SyncRun.Id);
+
+        var templateId = _relationshipTemplatesContext.CreateRelationshipTemplatesResponses[relationshipTemplateName].Id;
+
+        externalEvents.Result.Should().Contain(e =>
+            e.Type == "RelationshipTemplateAllocationsExhausted" &&
+            e.Payload["relationshipTemplateId"].GetString() == templateId);
     }
 
     #endregion

--- a/Modules/Relationships/src/Relationships.Domain/Aggregates/RelationshipTemplates/RelationshipTemplate.cs
+++ b/Modules/Relationships/src/Relationships.Domain/Aggregates/RelationshipTemplates/RelationshipTemplate.cs
@@ -67,6 +67,9 @@ public class RelationshipTemplate : Entity
             throw new DomainException(DomainErrors.MaxNumberOfAllocationsExhausted());
 
         Allocations.Add(new RelationshipTemplateAllocation(Id, identity, device));
+
+        if (Allocations.Count == MaxNumberOfAllocations)
+            RaiseDomainEvent(new RelationshipTemplateAllocationsExhaustedDomainEvent(this));
     }
 
     public void AnonymizeForIdentity(string didDomainName)

--- a/Modules/Relationships/src/Relationships.Domain/DomainEvents/Outgoing/RelationshipTemplateAllocationsExhaustedDomainEvent.cs
+++ b/Modules/Relationships/src/Relationships.Domain/DomainEvents/Outgoing/RelationshipTemplateAllocationsExhaustedDomainEvent.cs
@@ -1,0 +1,16 @@
+﻿using Backbone.BuildingBlocks.Domain.Events;
+using Backbone.Modules.Relationships.Domain.Aggregates.RelationshipTemplates;
+
+namespace Backbone.Modules.Relationships.Domain.DomainEvents.Outgoing;
+
+public class RelationshipTemplateAllocationsExhaustedDomainEvent : DomainEvent
+{
+    public RelationshipTemplateAllocationsExhaustedDomainEvent(RelationshipTemplate template) : base($"{template.Id}/maxNumberOfAllocationsExhausted")
+    {
+        RelationshipTemplateId = template.Id;
+        CreatedBy = template.CreatedBy;
+    }
+
+    public string RelationshipTemplateId { get; set; }
+    public string CreatedBy { get; set; }
+}

--- a/Modules/Synchronization/src/Synchronization.Application/DomainEvents/Incoming/RelationshipTemplateAllocationsExhausted/RelationshipTemplateAllocationsExhaustedDomainEventHandler.cs
+++ b/Modules/Synchronization/src/Synchronization.Application/DomainEvents/Incoming/RelationshipTemplateAllocationsExhausted/RelationshipTemplateAllocationsExhaustedDomainEventHandler.cs
@@ -1,0 +1,35 @@
+﻿using Backbone.BuildingBlocks.Application.Abstractions.Infrastructure.EventBus;
+using Backbone.Modules.Synchronization.Application.Infrastructure;
+using Backbone.Modules.Synchronization.Domain.DomainEvents.Incoming.RelationshipTemplateAllocationsExhausted;
+using Backbone.Modules.Synchronization.Domain.Entities.Sync;
+using Microsoft.Extensions.Logging;
+
+namespace Backbone.Modules.Synchronization.Application.DomainEvents.Incoming.RelationshipTemplateAllocationsExhausted;
+
+public class RelationshipTemplateAllocationsExhaustedDomainEventHandler : IDomainEventHandler<RelationshipTemplateAllocationsExhaustedDomainEvent>
+{
+    private readonly ISynchronizationDbContext _context;
+    private readonly ILogger<RelationshipTemplateAllocationsExhaustedDomainEventHandler> _logger;
+
+    public RelationshipTemplateAllocationsExhaustedDomainEventHandler(ISynchronizationDbContext context, ILogger<RelationshipTemplateAllocationsExhaustedDomainEventHandler> logger)
+    {
+        _context = context;
+        _logger = logger;
+    }
+
+    public async Task Handle(RelationshipTemplateAllocationsExhaustedDomainEvent @event)
+    {
+        try
+        {
+            var payload = new RelationshipTemplateAllocationsExhaustedExternalEvent.EventPayload { RelationshipTemplateId = @event.RelationshipTemplateId };
+            var externalEvent = new RelationshipTemplateAllocationsExhaustedExternalEvent(@event.CreatedBy, payload);
+
+            await _context.CreateExternalEvent(externalEvent);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An error occured while processing a domain event.");
+            throw;
+        }
+    }
+}

--- a/Modules/Synchronization/src/Synchronization.Application/Extensions/IEventBusExtensions.cs
+++ b/Modules/Synchronization/src/Synchronization.Application/Extensions/IEventBusExtensions.cs
@@ -9,6 +9,7 @@ using Backbone.Modules.Synchronization.Application.DomainEvents.Incoming.PeerToB
 using Backbone.Modules.Synchronization.Application.DomainEvents.Incoming.RelationshipReactivationCompleted;
 using Backbone.Modules.Synchronization.Application.DomainEvents.Incoming.RelationshipReactivationRequested;
 using Backbone.Modules.Synchronization.Application.DomainEvents.Incoming.RelationshipStatusChanged;
+using Backbone.Modules.Synchronization.Application.DomainEvents.Incoming.RelationshipTemplateAllocationsExhausted;
 using Backbone.Modules.Synchronization.Application.DomainEvents.Incoming.TokenLocked;
 using Backbone.Modules.Synchronization.Domain.DomainEvents.Incoming.IdentityDeletionProcessStarted;
 using Backbone.Modules.Synchronization.Domain.DomainEvents.Incoming.IdentityDeletionProcessStatusChanged;
@@ -20,6 +21,7 @@ using Backbone.Modules.Synchronization.Domain.DomainEvents.Incoming.PeerToBeDele
 using Backbone.Modules.Synchronization.Domain.DomainEvents.Incoming.RelationshipReactivationCompleted;
 using Backbone.Modules.Synchronization.Domain.DomainEvents.Incoming.RelationshipReactivationRequested;
 using Backbone.Modules.Synchronization.Domain.DomainEvents.Incoming.RelationshipStatusChanged;
+using Backbone.Modules.Synchronization.Domain.DomainEvents.Incoming.RelationshipTemplateAllocationsExhausted;
 using Backbone.Modules.Synchronization.Domain.DomainEvents.Incoming.TokenLocked;
 
 namespace Backbone.Modules.Synchronization.Application.Extensions;
@@ -32,6 +34,7 @@ public static class IEventBusExtensions
         {
             SubscribeToMessagesEvents(eventBus),
             SubscribeToRelationshipsEvents(eventBus),
+            SubscribeToRelationshipTemplatesEvents(eventBus),
             SubscribeToTokensEvents(eventBus)
         });
     }
@@ -60,9 +63,13 @@ public static class IEventBusExtensions
         });
     }
 
+    private static async Task SubscribeToRelationshipTemplatesEvents(IEventBus eventBus)
+    {
+        await eventBus.Subscribe<RelationshipTemplateAllocationsExhaustedDomainEvent, RelationshipTemplateAllocationsExhaustedDomainEventHandler>();
+    }
+
     private static async Task SubscribeToTokensEvents(IEventBus eventBus)
     {
         await eventBus.Subscribe<TokenLockedDomainEvent, TokenLockedDomainEventHandler>();
     }
-
 }

--- a/Modules/Synchronization/src/Synchronization.Application/SyncRuns/DTOs/ExternalEventDTO.cs
+++ b/Modules/Synchronization/src/Synchronization.Application/SyncRuns/DTOs/ExternalEventDTO.cs
@@ -41,6 +41,8 @@ public class ExternalEventDTO
 
             ExternalEventType.PeerFeatureFlagsChanged => "PeerFeatureFlagsChanged",
 
+            ExternalEventType.RelationshipTemplateAllocationsExhausted => "RelationshipTemplateAllocationsExhausted",
+
             _ => throw new ArgumentOutOfRangeException(nameof(externalEventType), externalEventType, null)
         };
     }

--- a/Modules/Synchronization/src/Synchronization.Domain/DomainEvents/Incoming/RelationshipTemplateAllocationsExhausted/RelationshipTemplateAllocationsExhaustedDomainEvent.cs
+++ b/Modules/Synchronization/src/Synchronization.Domain/DomainEvents/Incoming/RelationshipTemplateAllocationsExhausted/RelationshipTemplateAllocationsExhaustedDomainEvent.cs
@@ -1,0 +1,9 @@
+﻿using Backbone.BuildingBlocks.Domain.Events;
+
+namespace Backbone.Modules.Synchronization.Domain.DomainEvents.Incoming.RelationshipTemplateAllocationsExhausted;
+
+public class RelationshipTemplateAllocationsExhaustedDomainEvent : DomainEvent
+{
+    public required string RelationshipTemplateId { get; set; }
+    public required string CreatedBy { get; set; }
+}

--- a/Modules/Synchronization/src/Synchronization.Domain/Entities/Sync/ExternalEvent.cs
+++ b/Modules/Synchronization/src/Synchronization.Domain/Entities/Sync/ExternalEvent.cs
@@ -93,5 +93,7 @@ public enum ExternalEventType
 
     TokenLocked = 30,
 
-    PeerFeatureFlagsChanged = 40
+    PeerFeatureFlagsChanged = 40,
+
+    RelationshipTemplateAllocationsExhausted = 50
 }

--- a/Modules/Synchronization/src/Synchronization.Domain/Entities/Sync/RelationshipTemplateAllocationsExhaustedExternalEvent.cs
+++ b/Modules/Synchronization/src/Synchronization.Domain/Entities/Sync/RelationshipTemplateAllocationsExhaustedExternalEvent.cs
@@ -1,0 +1,22 @@
+﻿using Backbone.DevelopmentKit.Identity.ValueObjects;
+
+namespace Backbone.Modules.Synchronization.Domain.Entities.Sync;
+
+public class RelationshipTemplateAllocationsExhaustedExternalEvent : ExternalEvent
+{
+    // ReSharper disable once UnusedMember.Local
+    private RelationshipTemplateAllocationsExhaustedExternalEvent()
+    {
+        // This constructor is for EF Core only; initializing the properties with null is therefore not a problem
+    }
+
+    public RelationshipTemplateAllocationsExhaustedExternalEvent(IdentityAddress owner, EventPayload payload)
+        : base(ExternalEventType.RelationshipTemplateAllocationsExhausted, owner, payload)
+    {
+    }
+
+    public record EventPayload
+    {
+        public required string RelationshipTemplateId { get; init; }
+    }
+}


### PR DESCRIPTION
# Readiness checklist

-   [ ] I added/updated unit tests.
-   [x] I added/updated integration tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.
