### PR TITLE
Simplify announcement returned by Consumer API

### DIFF
--- a/Modules/Announcements/src/Announcements.Application/Announcements/DTOs/SingleLanguageAnnouncementDTO.cs
+++ b/Modules/Announcements/src/Announcements.Application/Announcements/DTOs/SingleLanguageAnnouncementDTO.cs
@@ -18,12 +18,14 @@ public class SingleLanguageAnnouncementDTO
         var textInLanguage = announcement.Texts.SingleOrDefault(t => t.Language == language) ??
                              announcement.Texts.Single(t => t.Language == AnnouncementLanguage.DEFAULT_LANGUAGE);
 
-        Text = new AnnouncementTextDTO(textInLanguage);
+        Title = textInLanguage.Title;
+        Body = textInLanguage.Body;
     }
 
     public string Id { get; }
     public DateTime CreatedAt { get; }
     public DateTime? ExpiresAt { get; }
     public AnnouncementSeverity Severity { get; }
-    public AnnouncementTextDTO Text { get; }
+    public string Title { get; set; }
+    public string Body { get; set; }
 }


### PR DESCRIPTION
# Readiness checklist

-   [ ] I added/updated unit tests.
-   [ ] I added/updated integration tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.

I just noticed that it doesn't make a lot of sense to return `Title` and `Body` as part of a `Text` property. We only have that `Text` property in case of the Admin API, because there it has the `Language` property as well. But for the Consumer API, since there is only one language, we don't need that language.