### PR TITLE
Helm chart cannot be deployed because of incorrect HttpRoute configuration

### DIFF
--- a/helm/templates/consumerapi/httproute.yaml
+++ b/helm/templates/consumerapi/httproute.yaml
@@ -36,6 +36,10 @@ spec:
         - path:
             type: Exact
             value: /.well-known/jwks
+      backendRefs:
+        - name: {{ .Values.consumerapi.name }}
+          port: 8080
+    - matches:
         - path:
             type: PathPrefix
             value: /api

--- a/helm/templates/consumerapi/httproute.yaml
+++ b/helm/templates/consumerapi/httproute.yaml
@@ -25,6 +25,20 @@ spec:
             type: Exact
             value: /health
         - path:
+            type: PathPrefix
+            value: /api
+        - path:
+            type: PathPrefix
+            value: /style
+        - path:
+            type: PathPrefix
+            value: /r
+      backendRefs:
+        - name: {{ .Values.consumerapi.name }}
+          port: 8080
+    - matches:
+      backendRefs:
+        - path:
             type: Exact
             value: /.well-known/assetlinks.json
         - path:
@@ -36,20 +50,6 @@ spec:
         - path:
             type: Exact
             value: /.well-known/jwks
-      backendRefs:
-        - name: {{ .Values.consumerapi.name }}
-          port: 8080
-    - matches:
-        - path:
-            type: PathPrefix
-            value: /api
-        - path:
-            type: PathPrefix
-            value: /style
-        - path:
-            type: PathPrefix
-            value: /r
-      backendRefs:
         - name: {{ .Values.consumerapi.name }}
           port: 8080
 {{- end }}


### PR DESCRIPTION
# Readiness checklist

-   [ ] I added/updated unit tests.
-   [ ] I added/updated integration tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.
