### PR TITLE
Moving to QueuedForDeletion tier requires unnecessarily much time for recalculating metric statuses

### DIFF
--- a/BuildingBlocks/test/BuildingBlocks.API.Tests/BuildingBlocks.API.Tests.csproj
+++ b/BuildingBlocks/test/BuildingBlocks.API.Tests/BuildingBlocks.API.Tests.csproj
@@ -6,7 +6,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="[17.14.1]" />
-    <PackageReference Include="FluentAssertions" Version="7.0.0" />
     <PackageReference Include="GitHubActionsTestLogger" Version="[2.4.1]">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/BuildingBlocks/test/UnitTestTools.Tests/UnitTestTools.Tests.csproj
+++ b/BuildingBlocks/test/UnitTestTools.Tests/UnitTestTools.Tests.csproj
@@ -6,7 +6,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="[17.14.1]" />
-		<PackageReference Include="FluentAssertions" Version="7.0.0" />
 		<PackageReference Include="GitHubActionsTestLogger" Version="[2.4.1]">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>

--- a/Modules/Quotas/src/Quotas.Domain/Aggregates/Identities/Identity.cs
+++ b/Modules/Quotas/src/Quotas.Domain/Aggregates/Identities/Identity.cs
@@ -126,7 +126,7 @@ public class Identity : Entity
         {
             // if the quota allows 0, we don't need to calculate the usage, it's always exhausted
             // this is primarily an optimization for when an identity moves to the QueuedForDeletion tier, where all quotas are set to 0
-            var newUsage = quota.Max > 0
+            var newUsage = quota.Max == 0
                 ? 1
                 : await metricCalculator.CalculateUsage(
                     quota.Period.CalculateBegin(utcNow),

--- a/Modules/Quotas/src/Quotas.Domain/Aggregates/Identities/Identity.cs
+++ b/Modules/Quotas/src/Quotas.Domain/Aggregates/Identities/Identity.cs
@@ -17,7 +17,7 @@ public class Identity : Entity
     private readonly List<IndividualQuota> _individualQuotas;
     private readonly List<MetricStatus> _metricStatuses;
 
-    private readonly object _latestExhaustionDateLock = new();
+    private readonly Lock _latestExhaustionDateLock = new();
 
     // ReSharper disable once UnusedMember.Local
     protected Identity()

--- a/Modules/Quotas/src/Quotas.Domain/Aggregates/Identities/Identity.cs
+++ b/Modules/Quotas/src/Quotas.Domain/Aggregates/Identities/Identity.cs
@@ -127,7 +127,7 @@ public class Identity : Entity
             // if the quota allows 0, we don't need to calculate the usage, it's always exhausted
             // this is primarily an optimization for when an identity moves to the QueuedForDeletion tier, where all quotas are set to 0
             var newUsage = quota.Max == 0
-                ? 1
+                ? (uint)quota.Max
                 : await metricCalculator.CalculateUsage(
                     quota.Period.CalculateBegin(utcNow),
                     quota.Period.CalculateEnd(utcNow),

--- a/Modules/Quotas/test/Quotas.Domain.Tests/Tests/Identities/IdentityTests.cs
+++ b/Modules/Quotas/test/Quotas.Domain.Tests/Tests/Identities/IdentityTests.cs
@@ -301,8 +301,6 @@ public class IdentityTests : AbstractTestsBase
     public async Task Updating_a_MetricStatus_with_Quota_with_max_0()
     {
         // Arrange
-        SystemTime.Set(DateTime.Parse("2023-01-15T12:00:00"));
-
         var identity = CreateIdentity();
         identity.AssignTierQuotaFromDefinition(new TierQuotaDefinition(MetricKey.NUMBER_OF_SENT_MESSAGES, 0, QuotaPeriod.Hour));
 

--- a/Modules/Quotas/test/Quotas.Domain.Tests/Tests/Identities/IdentityTests.cs
+++ b/Modules/Quotas/test/Quotas.Domain.Tests/Tests/Identities/IdentityTests.cs
@@ -298,6 +298,22 @@ public class IdentityTests : AbstractTestsBase
     }
 
     [Fact]
+    public async Task Updating_a_MetricStatus_with_Quota_with_max_0()
+    {
+        // Arrange
+        SystemTime.Set(DateTime.Parse("2023-01-15T12:00:00"));
+
+        var identity = CreateIdentity();
+        identity.AssignTierQuotaFromDefinition(new TierQuotaDefinition(MetricKey.NUMBER_OF_SENT_MESSAGES, 0, QuotaPeriod.Hour));
+
+        // Act
+        await identity.UpdateMetricStatuses([MetricKey.NUMBER_OF_SENT_MESSAGES], new MetricCalculatorFactoryStub(0), MetricUpdateType.All);
+
+        // Assert
+        identity.MetricStatuses.First().IsExhaustedUntil.ShouldBeEndOfHour();
+    }
+
+    [Fact]
     public async Task Updating_an_already_exhausted_MetricStatus_with_an_even_higher_usage_recalculates_exhaustion_date()
     {
         // Even though this case will probably never happen in reality (because once the MetricStatus is exhausted, there will be no more updates), we should still test it


### PR DESCRIPTION
# Readiness checklist

-   [x] I added/updated unit tests.
-   [ ] I added/updated integration tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.
