### PR TITLE
Upgrade docker/login-action

### DIFF
--- a/.github/workflows/publish-artifacthub.yml
+++ b/.github/workflows/publish-artifacthub.yml
@@ -17,7 +17,7 @@ jobs:
           sudo mv oras /usr/local/bin
           rm oras.tar.gz
       - name: Docker Login
-        uses: docker/login-action@v3.7.0
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Login to dhi.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: dhi.io
           username: ${{ secrets.DHI_DOCKERHUB_USERNAME }}
@@ -24,13 +24,13 @@ jobs:
       - name: Install script dependencies
         run: npm install --prefix ./.ci
       - name: Docker Login
-        uses: docker/login-action@v3.7.0
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Log in to Docker Hub for accessing the cloud builder
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.CLOUD_BUILDER_USERNAME }}
           password: ${{ secrets.CLOUD_BUILDER_TOKEN }}
@@ -53,7 +53,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Login to dhi.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: dhi.io
           username: ${{ secrets.DHI_DOCKERHUB_USERNAME }}
@@ -61,13 +61,13 @@ jobs:
       - name: Install script dependencies
         run: npm install --prefix ./.ci
       - name: Docker Login
-        uses: docker/login-action@v3.7.0
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Log in to Docker Hub for accessing the cloud builder
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.CLOUD_BUILDER_USERNAME }}
           password: ${{ secrets.CLOUD_BUILDER_TOKEN }}
@@ -90,7 +90,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Login to dhi.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: dhi.io
           username: ${{ secrets.DHI_DOCKERHUB_USERNAME }}
@@ -98,13 +98,13 @@ jobs:
       - name: Install script dependencies
         run: npm install --prefix ./.ci
       - name: Docker Login
-        uses: docker/login-action@v3.7.0
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Log in to Docker Hub for accessing the cloud builder
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.CLOUD_BUILDER_USERNAME }}
           password: ${{ secrets.CLOUD_BUILDER_TOKEN }}
@@ -127,7 +127,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Login to dhi.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: dhi.io
           username: ${{ secrets.DHI_DOCKERHUB_USERNAME }}
@@ -135,13 +135,13 @@ jobs:
       - name: Install script dependencies
         run: npm install --prefix ./.ci
       - name: Docker Login
-        uses: docker/login-action@v3.7.0
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Log in to Docker Hub for accessing the cloud builder
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.CLOUD_BUILDER_USERNAME }}
           password: ${{ secrets.CLOUD_BUILDER_TOKEN }}
@@ -164,7 +164,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Login to dhi.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: dhi.io
           username: ${{ secrets.DHI_DOCKERHUB_USERNAME }}
@@ -172,13 +172,13 @@ jobs:
       - name: Install script dependencies
         run: npm install --prefix ./.ci
       - name: Docker Login
-        uses: docker/login-action@v3.7.0
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Log in to Docker Hub for accessing the cloud builder
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.CLOUD_BUILDER_USERNAME }}
           password: ${{ secrets.CLOUD_BUILDER_TOKEN }}
@@ -201,7 +201,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Login to dhi.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: dhi.io
           username: ${{ secrets.DHI_DOCKERHUB_USERNAME }}
@@ -209,13 +209,13 @@ jobs:
       - name: Install script dependencies
         run: npm install --prefix ./.ci
       - name: Docker Login
-        uses: docker/login-action@v3.7.0
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Log in to Docker Hub for accessing the cloud builder
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.CLOUD_BUILDER_USERNAME }}
           password: ${{ secrets.CLOUD_BUILDER_TOKEN }}
@@ -238,7 +238,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Login to dhi.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: dhi.io
           username: ${{ secrets.DHI_DOCKERHUB_USERNAME }}
@@ -246,13 +246,13 @@ jobs:
       - name: Install script dependencies
         run: npm install --prefix ./.ci
       - name: Docker Login
-        uses: docker/login-action@v3.7.0
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Log in to Docker Hub for accessing the cloud builder
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.CLOUD_BUILDER_USERNAME }}
           password: ${{ secrets.CLOUD_BUILDER_TOKEN }}
@@ -275,7 +275,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Login to dhi.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: dhi.io
           username: ${{ secrets.DHI_DOCKERHUB_USERNAME }}
@@ -283,13 +283,13 @@ jobs:
       - name: Install script dependencies
         run: npm install --prefix ./.ci
       - name: Docker Login
-        uses: docker/login-action@v3.7.0
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Log in to Docker Hub for accessing the cloud builder
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.CLOUD_BUILDER_USERNAME }}
           password: ${{ secrets.CLOUD_BUILDER_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,7 +121,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Login to dhi.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: dhi.io
           username: ${{ secrets.DHI_DOCKERHUB_USERNAME }}


### PR DESCRIPTION
# Readiness checklist

-   [ ] I ensured that the PR title is good enough for the changelog.
-   [ ] I labeled the PR.
-   [ ] I added/updated tests (if necessary).
-   [ ] I self-reviewed the PR.

# Description
The actions show a warning:

Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: docker/login-action@v3, docker/setup-buildx-action@v3. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/