### PR TITLE
fix(admin-ui): migrate multi-select dropdown to dropdown_button2 v3

### DIFF
--- a/Applications/AdminUi/apps/admin_ui/lib/core/widgets/filters/multi_select.dart
+++ b/Applications/AdminUi/apps/admin_ui/lib/core/widgets/filters/multi_select.dart
@@ -15,7 +15,13 @@ class MultiSelectFilter extends StatefulWidget {
 }
 
 class _MultiSelectFilterState extends State<MultiSelectFilter> {
-  final List<String> selectedItems = [];
+  final selectedItems = ValueNotifier<List<String>>([]);
+
+  @override
+  void dispose() {
+    selectedItems.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -30,33 +36,22 @@ class _MultiSelectFilterState extends State<MultiSelectFilter> {
             isExpanded: true,
             items: widget.options
                 .map(
-                  (item) => DropdownMenuItem(
+                  (item) => DropdownItem(
                     value: item.value,
-                    //disable default onTap to avoid closing menu when selecting an item
-                    enabled: false,
-                    child: StatefulBuilder(
-                      builder: (context, menuSetState) {
+                    closeOnTap: false,
+                    child: ValueListenableBuilder(
+                      valueListenable: selectedItems,
+                      builder: (context, selectedItems, _) {
                         final isSelected = selectedItems.contains(item.value);
-                        return InkWell(
-                          onTap: () {
-                            isSelected ? selectedItems.remove(item.value) : selectedItems.add(item.value);
-                            //This rebuilds the StatefulWidget to update the button's text
-                            setState(() {});
-                            //This rebuilds the dropdownMenu Widget to update the check mark
-                            menuSetState(() {});
-
-                            widget.onOptionSelected(selectedItems);
-                          },
-                          child: Container(
-                            height: double.infinity,
-                            padding: const EdgeInsets.symmetric(horizontal: 16),
-                            child: Row(
-                              children: [
-                                if (isSelected) const Icon(Icons.check_box_outlined) else const Icon(Icons.check_box_outline_blank),
-                                const SizedBox(width: 16),
-                                Expanded(child: Text(item.label, style: const TextStyle(fontSize: 14))),
-                              ],
-                            ),
+                        return Container(
+                          height: double.infinity,
+                          padding: const EdgeInsets.symmetric(horizontal: 16),
+                          child: Row(
+                            children: [
+                              if (isSelected) const Icon(Icons.check_box_outlined) else const Icon(Icons.check_box_outline_blank),
+                              const SizedBox(width: 16),
+                              Expanded(child: Text(item.label, style: const TextStyle(fontSize: 14))),
+                            ],
                           ),
                         );
                       },
@@ -64,18 +59,25 @@ class _MultiSelectFilterState extends State<MultiSelectFilter> {
                   ),
                 )
                 .toList(),
-            value: selectedItems.isEmpty ? null : selectedItems.last,
-            onChanged: (value) {},
+            multiValueListenable: selectedItems,
+            onChanged: (value) {
+              final newSelection = selectedItems.value.contains(value) ? ([...selectedItems.value]..remove(value)) : [...selectedItems.value, value!];
+              selectedItems.value = newSelection;
+              widget.onOptionSelected(newSelection);
+            },
             selectedItemBuilder: (context) => widget.options
                 .map(
-                  (_) => Text(
-                    widget.options.where((item) => selectedItems.contains(item.value)).map((item) => item.label).join(', '),
-                    maxLines: 1,
-                    overflow: .ellipsis,
+                  (_) => ValueListenableBuilder(
+                    valueListenable: selectedItems,
+                    builder: (context, selectedItems, _) => Text(
+                      widget.options.where((item) => selectedItems.contains(item.value)).map((item) => item.label).join(', '),
+                      maxLines: 1,
+                      overflow: .ellipsis,
+                    ),
                   ),
                 )
                 .toList(),
-            buttonStyleData: const ButtonStyleData(padding: .zero),
+            buttonStyleData: const FormFieldButtonStyleData(padding: .zero),
             menuItemStyleData: const MenuItemStyleData(padding: .zero),
             decoration: const InputDecoration(border: OutlineInputBorder()),
           ),

--- a/Applications/AdminUi/apps/admin_ui/pubspec.yaml
+++ b/Applications/AdminUi/apps/admin_ui/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   admin_api_types: ^1.0.0
   collection: any
   data_table_2: ^2.7.2
-  dropdown_button2: ^2.3.9
+  dropdown_button2: ^3.0.0
   flex_seed_scheme: ^4.0.1
   flutter:
     sdk: flutter

--- a/Applications/AdminUi/pubspec.lock
+++ b/Applications/AdminUi/pubspec.lock
@@ -229,10 +229,10 @@ packages:
     dependency: transitive
     description:
       name: dropdown_button2
-      sha256: b0fe8d49a030315e9eef6c7ac84ca964250155a6224d491c1365061bc974a9e1
+      sha256: "24f5b775483a9b3c508092766798c10e3f23127e66b3f4a305b5bfb59ff1debc"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.9"
+    version: "3.1.0"
   fake_async:
     dependency: transitive
     description:
@@ -790,10 +790,10 @@ packages:
     dependency: transitive
     description:
       name: translations_cleaner
-      sha256: "811f42be32f024fdf083903f198d3625f6ee6927601e3a53a29b85b90508b88c"
+      sha256: "96308250844e5451bb6e37f97a029a175caf90225db8e366cb328768bb3bef32"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.0"
+    version: "0.2.1"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
### Motivation

- Upgrade the Admin UI multi-select filter to support `dropdown_button2` v3, which replaces the old `value` API with `valueListenable`/`multiValueListenable` and introduces `DropdownItem`.
- Ensure the multi-select behavior (checkboxes, non-closing selection, and summary display) continues to work with the new API and update the lockfile accordingly.

### Description

- Rewrote `Applications/AdminUi/apps/admin_ui/lib/core/widgets/filters/multi_select.dart` to use a `ValueNotifier<List<String>>` for selection state, `DropdownItem` with `closeOnTap: false`, `multiValueListenable`, and `ValueListenableBuilder` for menu and button display updates, and added proper `dispose()` handling for the notifier.
- Replaced the previous manual menu-state handling with `onChanged` that updates the notifier and calls the provided `onOptionSelected` callback.
- Adjusted the form-field button style to use `FormFieldButtonStyleData` to match the v3 API.
- Updated `Applications/AdminUi/pubspec.lock` to resolve `dropdown_button2` to `3.1.0` (and refreshed related transitive entries like `translations_cleaner`).

### Testing

- Ran `./.ci/aui/runChecks.sh` for the Admin UI workspace and the checks completed successfully.
- Ran `melos test` for the workspace and all configured test runners completed successfully.
- Ran `flutter analyze` on the Admin UI and no issues were reported after the migration.
- Ran formatter via `melos format` / `dart format` and the modified files are formatted (no formatting failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a71a66fba1483238ae7e1e2a423f6a4)