### PR TITLE
Update Renovate dependency reviewers

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": ["github>js-soft/renovate-config"],
-    "additionalReviewers": ["erbenjak"],
+    "additionalReviewers": ["team:c-dependency-update-reviewers"],
     "packageRules": [
         {
             "description": "Don't report abandonment for these packages, because they are fine as they are.",


### PR DESCRIPTION
## Summary

- Replace the individual Renovate additional reviewer with the GitHub team `C# Dependency Update Reviewers` using Renovate's `team:c-dependency-update-reviewers` syntax.

## Validation

- `jq empty .github/renovate.json`