### PR TITLE
Use main for release dependency updates workflow

### DIFF
--- a/.github/workflows/weekly-release-of-dependency-updates.yml
+++ b/.github/workflows/weekly-release-of-dependency-updates.yml
@@ -14,6 +14,6 @@ concurrency:
 
 jobs:
   release:
-    uses: js-soft/github-actions/.github/workflows/release-dependency-updates.yml@3a8b30571a469d885af45763ecc9fcbf571e027a # main
+    uses: js-soft/github-actions/.github/workflows/release-dependency-updates.yml@main
     secrets:
       github-token: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
## Summary

- Point the weekly release dependency updates workflow at `js-soft/github-actions` on `main` instead of a pinned commit.

## Validation

- Not run; workflow reference-only change.