### PR TITLE
Add `/health/ready` and `/health/live` routes and use them for corresponding Kubernetes health checks to avoid automatic pod restarts if dependend services are unhealthy

### DIFF
--- a/Applications/AdminApi/src/AdminApi/Program.cs
+++ b/Applications/AdminApi/src/AdminApi/Program.cs
@@ -19,6 +19,7 @@ using Backbone.Modules.Quotas.Module;
 using Backbone.Modules.Tokens.Application;
 using Backbone.Modules.Tokens.Module;
 using Backbone.Tooling.Extensions;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Logging;
 using Serilog;
@@ -204,7 +205,18 @@ static void Configure(WebApplication app, AdminApiConfiguration configuration)
     app.MapControllers();
     app.MapFallbackToFile("{*path:regex(^(?!api/).*$)}", "index.html"); // don't match paths beginning with "api/"
 
-    app.MapHealthChecks("/health");
+    app.MapHealthChecks("/health", new HealthCheckOptions
+    {
+        Predicate = _ => false
+    });
+    app.MapHealthChecks("/health/ready", new HealthCheckOptions
+    {
+        Predicate = _ => true
+    });
+    app.MapHealthChecks("/health/live", new HealthCheckOptions
+    {
+        Predicate = _ => false
+    });
 }
 
 public partial class Program

--- a/Applications/ConsumerApi/src/Program.cs
+++ b/Applications/ConsumerApi/src/Program.cs
@@ -30,6 +30,7 @@ using Backbone.Modules.Tokens.Application;
 using Backbone.Modules.Tokens.Infrastructure.Persistence.Database;
 using Backbone.Modules.Tokens.Module;
 using Backbone.Tooling.Extensions;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Logging;
@@ -214,7 +215,18 @@ static void Configure(WebApplication app, ConsumerApiConfiguration configuration
 
     app.UseAuthentication().UseAuthorization();
     app.MapControllers();
-    app.MapHealthChecks("/health");
+    app.MapHealthChecks("/health", new HealthCheckOptions
+    {
+        Predicate = _ => false
+    });
+    app.MapHealthChecks("/health/ready", new HealthCheckOptions
+    {
+        Predicate = _ => true
+    });
+    app.MapHealthChecks("/health/live", new HealthCheckOptions
+    {
+        Predicate = _ => false
+    });
 
     app.UseResponseCaching();
 }

--- a/Applications/SseServer/src/SseServer/Program.cs
+++ b/Applications/SseServer/src/SseServer/Program.cs
@@ -10,6 +10,7 @@ using Backbone.Modules.Devices.Module;
 using Backbone.SseServer.Controllers;
 using Backbone.SseServer.Extensions;
 using Backbone.Tooling.Extensions;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.Options;
 using Serilog;
@@ -149,7 +150,18 @@ static void Configure(WebApplication app, Configuration configuration)
 
     app.MapControllers();
 
-    app.MapHealthChecks("/health");
+    app.MapHealthChecks("/health", new HealthCheckOptions
+    {
+        Predicate = _ => false
+    });
+    app.MapHealthChecks("/health/ready", new HealthCheckOptions
+    {
+        Predicate = _ => true
+    });
+    app.MapHealthChecks("/health/live", new HealthCheckOptions
+    {
+        Predicate = _ => false
+    });
 }
 
 static void LoadConfiguration(WebApplicationBuilder webApplicationBuilder, string[] strings)

--- a/helm/templates/adminui/deployment.yaml
+++ b/helm/templates/adminui/deployment.yaml
@@ -61,7 +61,7 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /health
+              path: /health/live
               port: 8080
             initialDelaySeconds: {{ .Values.adminui.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.adminui.livenessProbe.periodSeconds }}
@@ -69,7 +69,7 @@ spec:
             failureThreshold: {{ .Values.adminui.livenessProbe.failureThreshold }}
           readinessProbe:
             httpGet:
-              path: /health
+              path: /health/ready
               port: 8080
             initialDelaySeconds: {{ .Values.adminui.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.adminui.readinessProbe.periodSeconds }}

--- a/helm/templates/consumerapi/deployment.yaml
+++ b/helm/templates/consumerapi/deployment.yaml
@@ -83,7 +83,7 @@ spec:
             {{- include "generateEnvVars" (list .Values.global.env .Values.consumerapi.env) | nindent 12 }}
           livenessProbe:
             httpGet:
-              path: /health
+              path: /health/live
               port: 8080
             initialDelaySeconds: {{ .Values.consumerapi.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.consumerapi.livenessProbe.periodSeconds }}
@@ -91,7 +91,7 @@ spec:
             failureThreshold: {{ .Values.consumerapi.livenessProbe.failureThreshold }}
           readinessProbe:
             httpGet:
-              path: /health
+              path: /health/ready
               port: 8080
             initialDelaySeconds: {{ .Values.consumerapi.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.consumerapi.readinessProbe.periodSeconds }}

--- a/helm/templates/sseserver/deployment.yaml
+++ b/helm/templates/sseserver/deployment.yaml
@@ -84,7 +84,7 @@ spec:
             {{- include "generateEnvVars" (list .Values.global.env .Values.sseserver.env) | nindent 12 }}
           livenessProbe:
             httpGet:
-              path: /health
+              path: /health/live
               port: 8080
             initialDelaySeconds: {{ .Values.sseserver.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.sseserver.livenessProbe.periodSeconds }}
@@ -92,7 +92,7 @@ spec:
             failureThreshold: {{ .Values.sseserver.livenessProbe.failureThreshold }}
           readinessProbe:
             httpGet:
-              path: /health
+              path: /health/ready
               port: 8080
             initialDelaySeconds: {{ .Values.sseserver.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.sseserver.readinessProbe.periodSeconds }}


### PR DESCRIPTION
# Readiness checklist

- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I added tests (if necessary).
- [x] I self-reviewed the PR.

<!-- # Description -->
