### PR TITLE
Housekeeper: Deletion of orphaned blobs creates one db query per existing file

### DIFF
--- a/BuildingBlocks/src/UnitTestTools/TestDoubles/Fakes/FakeDbContextFactory.cs
+++ b/BuildingBlocks/src/UnitTestTools/TestDoubles/Fakes/FakeDbContextFactory.cs
@@ -2,19 +2,21 @@ using Backbone.BuildingBlocks.Application.Abstractions.Infrastructure.EventBus;
 using FakeItEasy;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 
 namespace Backbone.UnitTestTools.TestDoubles.Fakes;
 
 public static class FakeDbContextFactory
 {
     public static (TContext arrangeContext, TContext actContext, TContext assertionContext)
-        CreateDbContexts<TContext>(SqliteConnection? connection = null) where TContext : DbContext
+        CreateDbContexts<TContext>(SqliteConnection? connection = null, IEnumerable<DbCommandInterceptor>? interceptors = null) where TContext : DbContext
     {
         connection ??= CreateDbConnection();
         connection.Open();
 
         var options = new DbContextOptionsBuilder<TContext>()
             .UseSqlite(connection)
+            .AddInterceptors(interceptors ?? [])
             .Options;
 
         object[] args = [options, A.Dummy<IEventBus>()];

--- a/Modules/Files/src/Files.Infrastructure/Persistence/Database/Repository/FilesRepository.cs
+++ b/Modules/Files/src/Files.Infrastructure/Persistence/Database/Repository/FilesRepository.cs
@@ -16,6 +16,8 @@ namespace Backbone.Modules.Files.Infrastructure.Persistence.Database.Repository;
 
 public class FilesRepository : IFilesRepository
 {
+    private const int DELETE_ORPHANED_BLOB_IDS_BATCH_SIZE = 1000;
+
     private readonly DbSet<File> _files;
     private readonly IQueryable<File> _readOnlyFiles;
     private readonly FilesDbContext _dbContext;
@@ -89,19 +91,44 @@ public class FilesRepository : IFilesRepository
     public async Task<int> DeleteOrphanedBlobs(CancellationToken cancellationToken)
     {
         var allBlobIds = await _blobStorage.ListAsync(_blobConfiguration.RootFolder);
-        var orphanedBlobIds = allBlobIds.Where(b => _readOnlyFiles.All(f => f.Id != b));
-
         var numberOfDeletedBlobs = 0;
+        var blobIdBatch = new List<string>(DELETE_ORPHANED_BLOB_IDS_BATCH_SIZE);
 
-        await foreach (var blobId in orphanedBlobIds.WithCancellation(cancellationToken))
+        await foreach (var blobId in allBlobIds.WithCancellation(cancellationToken))
         {
-            _blobStorage.Remove(_blobConfiguration.RootFolder, blobId);
-            numberOfDeletedBlobs++;
+            blobIdBatch.Add(blobId);
+
+            if (blobIdBatch.Count < DELETE_ORPHANED_BLOB_IDS_BATCH_SIZE)
+                continue;
+
+            numberOfDeletedBlobs += await DeleteOrphanedBlobs(blobIdBatch, cancellationToken);
+            blobIdBatch.Clear();
         }
+
+        if (blobIdBatch.Count > 0)
+            numberOfDeletedBlobs += await DeleteOrphanedBlobs(blobIdBatch, cancellationToken);
 
         await _blobStorage.SaveAsync();
 
         return numberOfDeletedBlobs;
+    }
+
+    private async Task<int> DeleteOrphanedBlobs(List<string> blobIds, CancellationToken cancellationToken)
+    {
+        var existingFileIds = await _readOnlyFiles
+            .Where(file => blobIds.Contains(file.Id))
+            .Select(file => file.Id)
+            .ToListAsync(cancellationToken);
+
+        var existingBlobIds = existingFileIds.Select(fileId => fileId.Value).ToHashSet();
+        var orphanedBlobIds = blobIds.Where(blobId => !existingBlobIds.Contains(blobId)).ToList();
+
+        foreach (var blobId in orphanedBlobIds)
+        {
+            _blobStorage.Remove(_blobConfiguration.RootFolder, blobId);
+        }
+
+        return orphanedBlobIds.Count;
     }
 
     public async Task<File?> Get(FileId fileId, CancellationToken cancellationToken, bool track = false, bool fillContent = true)

--- a/Modules/Files/test/Files.Infrastructure.Tests/Tests/Repositories/FilesRepositoryTests.cs
+++ b/Modules/Files/test/Files.Infrastructure.Tests/Tests/Repositories/FilesRepositoryTests.cs
@@ -1,10 +1,14 @@
+using System.Data.Common;
 using Backbone.BuildingBlocks.Application.Abstractions.Infrastructure.Persistence.BlobStorage;
 using Backbone.DevelopmentKit.Identity.ValueObjects;
 using Backbone.Modules.Files.Application.Infrastructure.Persistence;
+using Backbone.Modules.Files.Domain.Entities;
 using Backbone.Modules.Files.Infrastructure.Persistence.Database;
 using Backbone.Modules.Files.Infrastructure.Persistence.Database.Repository;
+using Backbone.UnitTestTools.Extensions;
 using Backbone.UnitTestTools.TestDoubles.Fakes;
 using FakeItEasy;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Options;
 using File = Backbone.Modules.Files.Domain.Entities.File;
 
@@ -29,6 +33,38 @@ public class FilesRepositoryTests : AbstractTestsBase
         A.CallTo(() => mockBlobStorage.Remove(A<string>._, A<string>.That.Matches(fileId => files.Any(f => f.Id == fileId)))).MustHaveHappenedANumberOfTimesMatching(x => x == files.Count);
     }
 
+    [Fact]
+    public async Task Deletes_orphaned_blobs_using_batched_database_queries()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var fakeBlobStorage = A.Fake<IBlobStorage>();
+        var existingFile1 = GenerateFile(CreateRandomIdentityAddress());
+        var existingFile2 = GenerateFile(CreateRandomIdentityAddress());
+        var blobIds = Enumerable.Range(0, 1001).Select(_ => FileId.New().Value).ToList();
+        blobIds[0] = existingFile1.Id;
+        blobIds[1000] = existingFile2.Id;
+
+        A.CallTo(() => fakeBlobStorage.ListAsync(A<string>._, A<string?>._)).Returns(Task.FromResult(AsAsyncEnumerable(blobIds)));
+
+        var queryCounter = new QueryCounterInterceptor();
+
+        var (arrangeContext, actContext, _) = FakeDbContextFactory.CreateDbContexts<FilesDbContext>(interceptors: [queryCounter]);
+
+        await arrangeContext.SaveEntities(existingFile1, existingFile2);
+
+        queryCounter.Reset();
+
+        var repository = new FilesRepository(actContext, fakeBlobStorage, Options.Create(new BlobConfiguration { RootFolder = "" }));
+
+        // Act
+        var numberOfDeletedBlobs = await repository.DeleteOrphanedBlobs(cancellationToken);
+
+        // Assert
+        numberOfDeletedBlobs.ShouldBe(999);
+        queryCounter.NumberOfQueries.ShouldBe(2);
+    }
+
     private static File GenerateFile(IdentityAddress identityAddress)
     {
         return new File(identityAddress, CreateRandomDeviceId(), [], [], [], 0, DateTime.Now, []);
@@ -44,5 +80,33 @@ public class FilesRepositoryTests : AbstractTestsBase
         arrangeContext.SaveChanges();
 
         return new FilesRepository(actContext, mockBlobStorage, blobStorageOptions);
+    }
+
+    private static async IAsyncEnumerable<string> AsAsyncEnumerable(IEnumerable<string> values)
+    {
+        await Task.Yield();
+
+        foreach (var value in values)
+            yield return value;
+    }
+
+    private sealed class QueryCounterInterceptor : DbCommandInterceptor
+    {
+        public int NumberOfQueries { get; private set; }
+
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default)
+        {
+            NumberOfQueries++;
+            return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+        }
+
+        public void Reset()
+        {
+            NumberOfQueries = 0;
+        }
     }
 }


### PR DESCRIPTION
# Readiness checklist

- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I added tests (if necessary).
- [x] I self-reviewed the PR.

<!-- # Description -->
